### PR TITLE
Hotfix for duplicate address elements removal

### DIFF
--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -108,8 +108,7 @@ class AddressParser:
 
         self.pre_trained_model.eval()
 
-    def __call__(self,
-                 addresses_to_parse: Union[List[str], str],
+    def __call__(self, addresses_to_parse: Union[List[str], str],
                  with_prob: bool = False) -> Union[ParsedAddress, List[ParsedAddress]]:
         """
         Callable method to parse the components of an address or a list of address.
@@ -170,13 +169,13 @@ class AddressParser:
 
         for address_to_parse, tags_prediction, tags_prediction_prob in zip(addresses_to_parse, tags_predictions,
                                                                            tags_predictions_prob):
-            tagged_address_components = {}
+            tagged_address_components = []
             for word, predicted_idx_tag, tag_proba in zip(address_to_parse.split(), tags_prediction,
                                                           tags_prediction_prob):
                 tag = self.tags_converter(predicted_idx_tag)
                 if with_prob:
                     tag = (tag, round(tag_proba, self.rounding))
-                tagged_address_components[word] = tag
+                tagged_address_components.append((word, tag))
             tagged_addresses_components.append(ParsedAddress({address_to_parse: tagged_address_components}))
 
         if len(tagged_addresses_components) == 1:

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -108,7 +108,8 @@ class AddressParser:
 
         self.pre_trained_model.eval()
 
-    def __call__(self, addresses_to_parse: Union[List[str], str],
+    def __call__(self,
+                 addresses_to_parse: Union[List[str], str],
                  with_prob: bool = False) -> Union[ParsedAddress, List[ParsedAddress]]:
         """
         Callable method to parse the components of an address or a list of address.

--- a/deepparse/parser/parsed_address.py
+++ b/deepparse/parser/parsed_address.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List, Tuple
 
 
 class ParsedAddress:
@@ -8,12 +8,12 @@ class ParsedAddress:
     Note:
         Since an address component can be composed of multiple elements (e.g. Wolfe street), when the probability
         values are asked of the address parser, the address components don't keep it. It's only available through the
-        ``address_parsed_dict`` attribute.
+        ``address_parsed_components`` attribute.
 
     Attributes:
         raw_address: The raw address (not parsed).
-        address_parsed_dict: The parsed address in a dictionary where the keys are the address components and
-            the values are the tags.
+        address_parsed_components: The parsed address in a list of tuples where the first elements
+            are the address components and the second elements are the tags.
         street_number: The street number.
         unit: The street unit component.
         street_name: The street name.
@@ -36,13 +36,14 @@ class ParsedAddress:
     def __init__(self, address: Dict):
         """
         Args:
-            address: A dictionary where the key is an address, and the value is another dictionary where the keys are
-                address components, and the values are the parsed address value. Also, the second dictionary's
-                address value can either be the tag of the components (e.g. StreetName) or a tuple (``x``, ``y``)
-                where ``x`` is the tag and ``y`` is the probability (e.g. 0.9981) of the model prediction.
+            address: A dictionary where the key is an address, and the value is a list of tuples where
+            the first elements are address components, and the second elements are the parsed address
+            value. Also, the second tuple's address value can either be the tag of the components
+            (e.g. StreetName) or a tuple (``x``, ``y``) where ``x`` is the tag and ``y`` is the
+            probability (e.g. 0.9981) of the model prediction.
         """
         self.raw_address = list(address.keys())[0]
-        self.address_parsed_dict = address[self.raw_address]
+        self.address_parsed_components = address[self.raw_address]
 
         self.street_number = None
         self.unit = None
@@ -53,18 +54,18 @@ class ParsedAddress:
         self.postal_code = None
         self.general_delivery = None
 
-        self._resolve_tagged_affectation(self.address_parsed_dict)
+        self._resolve_tagged_affectation(self.address_parsed_components)
 
     def __str__(self) -> str:
         return self.raw_address
 
-    def _resolve_tagged_affectation(self, tagged_address: Dict) -> None:
+    def _resolve_tagged_affectation(self, tagged_address: List[Tuple]) -> None:
         """
         Private method to resolve the parsing of the tagged address.
         :param tagged_address: The tagged address where the keys are the address component and the values are the
         associated tag.
         """
-        for address_component, tag in tagged_address.items():
+        for address_component, tag in tagged_address:
             if isinstance(tag, tuple):  # when tag is also the tag and the probability of the tag
                 tag = tag[0]
             if tag == "StreetNumber":

--- a/tests/parser/test_parsed_address.py
+++ b/tests/parser/test_parsed_address.py
@@ -9,7 +9,7 @@ class ParsedAddressTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.a_address_str = '3 test road'
-        cls.a_parsed_address = {'3': 'StreetNumber', 'test': 'StreetName', 'road': 'StreetName'}
+        cls.a_parsed_address = [('3', 'StreetNumber'), ('test', 'StreetName'), ('road', 'StreetName')]
         cls.a_address = {cls.a_address_str: cls.a_parsed_address}
         cls.a_existing_tag = '3'
 
@@ -22,7 +22,7 @@ class ParsedAddressTest(TestCase):
         self.assertEqual(address, self.a_address_str)
 
     def test_whenInstanciatedWithAddress_thenShouldReturnCorrectParsedAddress(self):
-        parsed_address = self.parsed_address.address_parsed_dict
+        parsed_address = self.parsed_address.address_parsed_components
 
         self.assertEqual(parsed_address, self.a_parsed_address)
 


### PR DESCRIPTION
When building the address elements dict at:
https://github.com/GRAAL-Research/deepparse/blob/abdfe627db01d136fc21da337025767732892490/deepparse/parser/address_parser.py#L179

if there's a word repeated twice in an address, the second instance overrides the value of the first which is lost.

I fixed this by using a list of tuples instead of a dict and made the required changes in the source code and tests.

fixes #50 