### PR TITLE
Bug fix max len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,4 @@
 
 - We have improved the loading of data during prediction. We now use a data loader.
 - Fixed missing import in the parser module.
+- Bug fix of the `max_len` for the predictions

--- a/deepparse/network/bpemb_seq2seq.py
+++ b/deepparse/network/bpemb_seq2seq.py
@@ -55,7 +55,7 @@ class BPEmbSeq2SeqModel(Seq2SeqModel):
 
         decoder_input, decoder_hidden = self._encoder_step(embedded_output, lengths_tensor, batch_size)
 
-        max_length = lengths_tensor[0].item()
+        max_length = lengths_tensor.max().item()
         prediction_sequence = self._decoder_step(decoder_input, decoder_hidden, target, max_length, batch_size)
 
         return prediction_sequence

--- a/deepparse/network/fasttext_seq2seq.py
+++ b/deepparse/network/fasttext_seq2seq.py
@@ -49,7 +49,7 @@ class FastTextSeq2SeqModel(Seq2SeqModel):
 
         decoder_input, decoder_hidden = self._encoder_step(to_predict, lengths_tensor, batch_size)
 
-        max_length = lengths_tensor[0].item()
+        max_length = lengths_tensor.max().item()
         decoder_predict = self._decoder_step(decoder_input, decoder_hidden, target, max_length, batch_size)
 
         return decoder_predict


### PR DESCRIPTION
Since we don't sort the sequence (and the len of then) we were taking the max len as the first element of the max_len. So most of the cases we cut the sequence to tag. 