### PR TITLE
Improve unit parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,4 +228,4 @@ to `cache_dir`. `saving_dir` is now deprecated and will be remove in version 0.8
 - Improve handling of HTTP error in models version verification
 - Improve doc
 - Add a note for parsing data cleaning (i.e. lowercase, commas removal, and hyphen replacing).
-- Add hyphen parsing cleaning step to improve Canada address parsing.
+- Add hyphen parsing cleaning step to improve Canada address parsing (see [issue 137](https://github.com/GRAAL-Research/deepparse/issues/137)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,4 +227,5 @@ to `cache_dir`. `saving_dir` is now deprecated and will be remove in version 0.8
 - Add cache_dir arg in all CLI functions
 - Improve handling of HTTP error in models version verification
 - Improve doc
-- 
+- Add a note for parsing data cleaning (i.e. lowercase, commas removal, and hyphen replacing).
+- Add hyphen parsing cleaning step to improve Canada address parsing.

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -286,6 +286,11 @@ class AddressParser:
             Either a :class:`~FormattedParsedAddress` or a list of
             :class:`~FormattedParsedAddress` when given more than one address.
 
+        Note:
+            During the parsing, the addresses are lowercase, commas are removed, and hyphens are replaced but whitespace
+            for proper cleaning. Since the training dataset was lowercase, there were no comas, and no cases of a unit
+            linked to a street number were seen (e.g. 3-305, where 3 is the unit and 305 is the street number).
+
         Examples:
 
             .. code-block:: python

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -287,9 +287,10 @@ class AddressParser:
             :class:`~FormattedParsedAddress` when given more than one address.
 
         Note:
-            During the parsing, the addresses are lowercase, commas are removed, and hyphens are replaced but whitespace
-            for proper cleaning. Since the training dataset was lowercase, there were no comas, and no cases of a unit
-            linked to a street number were seen (e.g. 3-305, where 3 is the unit and 305 is the street number).
+            During the parsing, the addresses are lowercase, commas are removed, and hyphens (used to separate units
+            from street numbers, e.g. 3-305  a street name) are replaced by whitespace for proper cleaning. Since the
+            training dataset was lowercase, there were no commas, and few proper cases of a unit-linked to a street
+            number were seen (e.g. 3-305, where 3 is the unit and 305 is the street number).
 
         Examples:
 

--- a/deepparse/preprocessing/address_cleaner.py
+++ b/deepparse/preprocessing/address_cleaner.py
@@ -1,4 +1,10 @@
+import re
 from typing import List
+
+# The first group is the unit, and the second is the street number.
+# Both include letters since they can include letters in some countries. For example,
+# unit 3a or address 305a.
+hyphen_splitted_unit_and_street_number_regex = r"^([0-9a-z]*)-([0-9a-z]*)"
 
 
 class AddressCleaner:
@@ -8,9 +14,9 @@ class AddressCleaner:
         for address in addresses:
             processed_address = self.coma_cleaning(address)
 
-            processed_address = self.hyphen_cleaning(processed_address)
-
             processed_address = self.lower_cleaning(processed_address)
+
+            processed_address = self.hyphen_cleaning(processed_address)
 
             res.append(" ".join(processed_address.split()))
         return res
@@ -27,10 +33,11 @@ class AddressCleaner:
 
     @staticmethod
     def hyphen_cleaning(text: str) -> str:
-        # Since some addresses use the hyphen to split the unit and street address
+        # See issue 137 for more details https://github.com/GRAAL-Research/deepparse/issues/137.
+        # Since some addresses use the hyphen to split the unit and street address, we replace the hyphen
+        # with whitespaces to allow a proper splitting of the address.
         # For example, the proper parsing of the address 3-305 street name is
         # Unit: 3, StreetNumber: 305, StreetName: street name.
-        # We replace the hyphen with whitespaces since we use it for splitting,
-        # thus, it will allow a proper splitting of the address.
-        # See issue 137 for more details https://github.com/GRAAL-Research/deepparse/issues/137.
-        return text.replace("-", " ")
+        # Note: the hyphen is also used in some cities' names, such as Saint-Jean; thus, we use regex to detect
+        # the proper hyphen to replace.
+        return re.sub(hyphen_splitted_unit_and_street_number_regex, r"\1 \2", text)

--- a/deepparse/preprocessing/address_cleaner.py
+++ b/deepparse/preprocessing/address_cleaner.py
@@ -4,7 +4,7 @@ from typing import List
 # The first group is the unit, and the second is the street number.
 # Both include letters since they can include letters in some countries. For example,
 # unit 3a or address 305a.
-hyphen_splitted_unit_and_street_number_regex = r"^([0-9a-z]*)-([0-9a-z]*)"
+hyphen_splitted_unit_and_street_number_regex = r"^([0-9]*[a-z]?)-([0-9]*[a-z]?)"
 
 
 class AddressCleaner:

--- a/deepparse/preprocessing/address_cleaner.py
+++ b/deepparse/preprocessing/address_cleaner.py
@@ -8,6 +8,8 @@ class AddressCleaner:
         for address in addresses:
             processed_address = self.coma_cleaning(address)
 
+            processed_address = self.hyphen_cleaning(processed_address)
+
             processed_address = self.lower_cleaning(processed_address)
 
             res.append(" ".join(processed_address.split()))
@@ -22,3 +24,13 @@ class AddressCleaner:
     def lower_cleaning(text: str) -> str:
         # Since the original training data was in lowercase
         return text.lower()
+
+    @staticmethod
+    def hyphen_cleaning(text: str) -> str:
+        # Since some addresses use the hyphen to split the unit and street address
+        # For example, the proper parsing of the address 3-305 street name is
+        # Unit: 3, StreetNumber: 305, StreetName: street name.
+        # We replace the hyphen with whitespaces since we use it for splitting,
+        # thus, it will allow a proper splitting of the address.
+        # See issue 137 for more details https://github.com/GRAAL-Research/deepparse/issues/137.
+        return text.replace("-", " ")

--- a/tests/preprocessing/test_address_cleaner.py
+++ b/tests/preprocessing/test_address_cleaner.py
@@ -8,8 +8,11 @@ class AddressCleanerTest(TestCase):
     def setUpClass(cls):
         cls.a_clean_address = "350 rue des lilas ouest québec québec g1l 1b6"
         cls.a_dirty_address_with_commas = "350 rue des lilas , ouest ,québec québec, g1l 1b6"
+        cls.a_commas_separated_address = "350, rue des lilas, ouest, québec, québec, g1l 1b6"
         cls.a_dirty_address_with_uppercase = "350 rue des Lilas Ouest Québec Québec G1L 1B6"
         cls.a_dirty_address_with_whitespaces = "350     rue des Lilas Ouest Québec Québec G1L 1B6"
+        cls.an_address_with_hyphen_split_address_components = "3-350 rue des lilas ouest"
+        cls.a_unit_clean_address = "3 350 rue des lilas ouest"
 
     def test_givenACleanAddress_whenCleaningAddress_thenShouldNotMakeAnyChange(self):
         cleaned_address = AddressCleaner().clean([self.a_clean_address])
@@ -20,6 +23,10 @@ class AddressCleanerTest(TestCase):
         self,
     ):
         cleaned_address = AddressCleaner().clean([self.a_dirty_address_with_commas])
+
+        self.assertEqual(self.a_clean_address, cleaned_address[0])
+
+        cleaned_address = AddressCleaner().clean([self.a_commas_separated_address])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
@@ -44,3 +51,8 @@ class AddressCleanerTest(TestCase):
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
         self.assertEqual(self.a_clean_address, cleaned_address[1])
+
+    def test_givenAHyphenUnitStreetNumberAddress_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
+        cleaned_address = AddressCleaner().clean([self.an_address_with_hyphen_split_address_components])
+
+        self.assertEqual(self.a_unit_clean_address, cleaned_address[0])

--- a/tests/preprocessing/test_address_cleaner.py
+++ b/tests/preprocessing/test_address_cleaner.py
@@ -11,8 +11,24 @@ class AddressCleanerTest(TestCase):
         cls.a_commas_separated_address = "350, rue des lilas, ouest, québec, québec, g1l 1b6"
         cls.a_dirty_address_with_uppercase = "350 rue des Lilas Ouest Québec Québec G1L 1B6"
         cls.a_dirty_address_with_whitespaces = "350     rue des Lilas Ouest Québec Québec G1L 1B6"
+
         cls.an_address_with_hyphen_split_address_components = "3-350 rue des lilas ouest"
         cls.a_unit_clean_address = "3 350 rue des lilas ouest"
+
+        cls.an_address_with_hyphen_split_address_components_with_hyphen_city = "3-350 rue des lilas ouest, saint-jean"
+        cls.a_unit_hyphen_city_name_clean_address = "3 350 rue des lilas ouest saint-jean"
+
+        cls.a_unit_with_letter_hyphen_split = "3a-350 rue des lilas ouest saint-jean"
+        cls.a_unit_with_letter_hyphen_split_clean_address = "3a 350 rue des lilas ouest saint-jean"
+
+        cls.a_unit_with_letter_only_hyphen_split = "a-350 rue des lilas ouest saint-jean"
+        cls.a_unit_with_letter_only_hyphen_split_clean_address = "a 350 rue des lilas ouest saint-jean"
+
+        cls.a_street_number_with_letter_hyphen_split = "3-350a rue des lilas ouest saint-jean"
+        cls.a_street_number_with_letter_hyphen_split_clean_address = "3 350a rue des lilas ouest saint-jean"
+
+        cls.letters_hyphen_address = "3a-350b rue des lilas ouest saint-jean"
+        cls.letters_hyphen_address_split_clean_address = "3a 350b rue des lilas ouest saint-jean"
 
     def test_givenACleanAddress_whenCleaningAddress_thenShouldNotMakeAnyChange(self):
         cleaned_address = AddressCleaner().clean([self.a_clean_address])
@@ -56,3 +72,34 @@ class AddressCleanerTest(TestCase):
         cleaned_address = AddressCleaner().clean([self.an_address_with_hyphen_split_address_components])
 
         self.assertEqual(self.a_unit_clean_address, cleaned_address[0])
+
+    def test_givenAHyphenUnitAndCityAddress_whenCleaningAddress_thenShouldReplaceUnitStreetNumberHyphenWithWhiteSpace(
+        self,
+    ):
+        cleaned_address = AddressCleaner().clean(
+            [self.an_address_with_hyphen_split_address_components_with_hyphen_city]
+        )
+
+        self.assertEqual(self.a_unit_hyphen_city_name_clean_address, cleaned_address[0])
+
+    def test_givenAnAlphabeticalUnitStreetNumberHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
+        cleaned_address = AddressCleaner().clean([self.a_unit_with_letter_hyphen_split])
+
+        self.assertEqual(self.a_unit_with_letter_hyphen_split_clean_address, cleaned_address[0])
+
+    def test_givenAnAlphabeticalOnlyUnitHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
+        cleaned_address = AddressCleaner().clean([self.a_unit_with_letter_only_hyphen_split])
+
+        self.assertEqual(self.a_unit_with_letter_only_hyphen_split_clean_address, cleaned_address[0])
+
+    def test_givenAnAlphabeticalStreetNumberUnitHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
+        cleaned_address = AddressCleaner().clean([self.a_street_number_with_letter_hyphen_split])
+
+        self.assertEqual(self.a_street_number_with_letter_hyphen_split_clean_address, cleaned_address[0])
+
+    def test_givenAnAlphabeticalComponentsStreetNumberUnit_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(
+        self,
+    ):
+        cleaned_address = AddressCleaner().clean([self.letters_hyphen_address])
+
+        self.assertEqual(self.letters_hyphen_address_split_clean_address, cleaned_address[0])

--- a/tests/preprocessing/test_address_cleaner.py
+++ b/tests/preprocessing/test_address_cleaner.py
@@ -30,38 +30,40 @@ class AddressCleanerTest(TestCase):
         cls.letters_hyphen_address = "3a-350b rue des lilas ouest saint-jean"
         cls.letters_hyphen_address_split_clean_address = "3a 350b rue des lilas ouest saint-jean"
 
+        cls.address_cleaner = AddressCleaner()
+
     def test_givenACleanAddress_whenCleaningAddress_thenShouldNotMakeAnyChange(self):
-        cleaned_address = AddressCleaner().clean([self.a_clean_address])
+        cleaned_address = self.address_cleaner.clean([self.a_clean_address])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
     def test_givenADirtyAddressWithCommas_whenCleaningAddress_thenShouldRemoveCommas(
         self,
     ):
-        cleaned_address = AddressCleaner().clean([self.a_dirty_address_with_commas])
+        cleaned_address = self.address_cleaner.clean([self.a_dirty_address_with_commas])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
-        cleaned_address = AddressCleaner().clean([self.a_commas_separated_address])
+        cleaned_address = self.address_cleaner.clean([self.a_commas_separated_address])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
     def test_givenADirtyAddressWithUppercase_whenCleaningAddress_thenShouldLower(self):
-        cleaned_address = AddressCleaner().clean([self.a_dirty_address_with_uppercase])
+        cleaned_address = self.address_cleaner.clean([self.a_dirty_address_with_uppercase])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
     def test_givenADirtyAddressWithWhitespaces_whenCleaningAddress_thenShouldRemoveWhitespaces(
         self,
     ):
-        cleaned_address = AddressCleaner().clean([self.a_dirty_address_with_whitespaces])
+        cleaned_address = self.address_cleaner.clean([self.a_dirty_address_with_whitespaces])
 
         self.assertEqual(self.a_clean_address, cleaned_address[0])
 
     def test_givenMultipleDirtyAddresses_whenCleaningAddresses_thenShouldCleanAllAddresses(
         self,
     ):
-        cleaned_address = AddressCleaner().clean(
+        cleaned_address = self.address_cleaner.clean(
             [self.a_dirty_address_with_whitespaces, self.a_dirty_address_with_uppercase]
         )
 
@@ -69,37 +71,37 @@ class AddressCleanerTest(TestCase):
         self.assertEqual(self.a_clean_address, cleaned_address[1])
 
     def test_givenAHyphenUnitStreetNumberAddress_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
-        cleaned_address = AddressCleaner().clean([self.an_address_with_hyphen_split_address_components])
+        cleaned_address = self.address_cleaner.clean([self.an_address_with_hyphen_split_address_components])
 
         self.assertEqual(self.a_unit_clean_address, cleaned_address[0])
 
     def test_givenAHyphenUnitAndCityAddress_whenCleaningAddress_thenShouldReplaceUnitStreetNumberHyphenWithWhiteSpace(
         self,
     ):
-        cleaned_address = AddressCleaner().clean(
+        cleaned_address = self.address_cleaner.clean(
             [self.an_address_with_hyphen_split_address_components_with_hyphen_city]
         )
 
         self.assertEqual(self.a_unit_hyphen_city_name_clean_address, cleaned_address[0])
 
     def test_givenAnAlphabeticalUnitStreetNumberHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
-        cleaned_address = AddressCleaner().clean([self.a_unit_with_letter_hyphen_split])
+        cleaned_address = self.address_cleaner.clean([self.a_unit_with_letter_hyphen_split])
 
         self.assertEqual(self.a_unit_with_letter_hyphen_split_clean_address, cleaned_address[0])
 
     def test_givenAnAlphabeticalOnlyUnitHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
-        cleaned_address = AddressCleaner().clean([self.a_unit_with_letter_only_hyphen_split])
+        cleaned_address = self.address_cleaner.clean([self.a_unit_with_letter_only_hyphen_split])
 
         self.assertEqual(self.a_unit_with_letter_only_hyphen_split_clean_address, cleaned_address[0])
 
     def test_givenAnAlphabeticalStreetNumberUnitHyphen_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(self):
-        cleaned_address = AddressCleaner().clean([self.a_street_number_with_letter_hyphen_split])
+        cleaned_address = self.address_cleaner.clean([self.a_street_number_with_letter_hyphen_split])
 
         self.assertEqual(self.a_street_number_with_letter_hyphen_split_clean_address, cleaned_address[0])
 
     def test_givenAnAlphabeticalComponentsStreetNumberUnit_whenCleaningAddress_thenShouldReplaceHyphenWithWhiteSpace(
         self,
     ):
-        cleaned_address = AddressCleaner().clean([self.letters_hyphen_address])
+        cleaned_address = self.address_cleaner.clean([self.letters_hyphen_address])
 
         self.assertEqual(self.letters_hyphen_address_split_clean_address, cleaned_address[0])


### PR DESCRIPTION
Fixe #137 

Add a hyphen split for unit-street number cases.

## Performances
Out-of-the-box performances evaluated on a [new dataset for these cases](https://github.com/GRAAL-Research/deepparse-address-data#about-the-hyphen_unit_street_numberp-data) yields the following performance.

| Model Type  | Accuracy |
|-------------|----------|
| FastText    | 86,50    |
| FaxtTextAtt | 87,72    |
| BPEmb       | 71,85    |
| BPEmbAtt    | 87,81    |

Newer retrain models will be released soon to improve performance for these cases while not reducing performance for other cases.
