### PR TITLE
Bug fix retrain model loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,3 +308,4 @@
   multiprocess was set properly. Now, we set it properly and raise a warning instead of an error.
 - Drop Python 3.7 support since newer Python versions are faster
   and [Torch 2.0 does not support Python 3.7](https://dev-discuss.pytorch.org/t/dropping-support-for-cuda-11-6-and-python-3-7-from-pytorch-2-0-release/1021).
+- Improve error handling with wrong checkpoint loading in AddressParser retrain_path use.

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -223,11 +223,11 @@ class AddressParser:
 
         if path_to_retrained_model is not None:
             checkpoint_weights = torch.load(path_to_retrained_model, map_location="cpu")
-            if checkpoint_weights.get("named_parser") is None:
-                # Validate if we have the proper metadata, it has at least the parser name
+            if checkpoint_weights.get("model_type") is None:
+                # Validate if we have the proper metadata, it has at least the parser model type
                 # if no other thing have been modified.
                 raise RuntimeError(
-                    "You are not using the proper retrained checkpoint."
+                    "You are not using the proper retrained checkpoint. "
                     "When we retrain an AddressParser, by default, we create a "
                     "checkpoint name 'retrained_modeltype_address_parser.ckpt'. Be sure to use that"
                     "checkpoint since it includes some metadata for the reloading."

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -770,23 +770,20 @@ class AddressParser:
                     retrained_address_parser_in_directory = get_address_parser_in_directory(files_in_directory)[
                         0
                     ].split("_")[1]
-                    logging_dir_checkpoint_model = AddressParser(
-                        path_to_retrained_model=os.path.join(logging_path, retrained_address_parser_in_directory)
-                    )
-                    if self.is_same_model_type(logging_dir_checkpoint_model):
+                    if self.model_type == retrained_address_parser_in_directory:
                         value_error_message = (
-                            f"You are currently retraining a different {self.model_type} AddressParser configuration "
-                            "from in the same directory as a previous retrained model."
+                            f"You are currently retraining a different {self.get_formatted_model_name()} AddressParser "
+                            f"configuration in the same directory as a previous retrained model. "
                             "The configurations must be different (number of tag, seq2seq dimensions, etc.). "
                             "The easiest thing to do is to change the saving directory to avoid colliding checkpoint."
                         )
                     else:
                         value_error_message = (
-                            f"You are currently training a {self.model_type} in the directory "
+                            f"You are currently training a {self.get_formatted_model_name()} in the directory "
                             f"{logging_path} where a different retrained "
-                            f"{logging_dir_checkpoint_model.model_type} model is currently his."
-                            f" Thus, the loading of the model checkpoint is failing. Change the logging path "
-                            f'"{logging_path}" to something else to retrain the {self.model_type} model.'
+                            f"{retrained_address_parser_in_directory} model is currently his. "
+                            f"Thus, the loading of the model checkpoint is failing. Change the logging path "
+                            f'"{logging_path}" to something else to retrain the {self.get_formatted_model_name()} model.'
                         )
 
                     raise ValueError(value_error_message) from error

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -783,7 +783,8 @@ class AddressParser:
                             f"{logging_path} where a different retrained "
                             f"{retrained_address_parser_in_directory} model is currently his. "
                             f"Thus, the loading of the model checkpoint is failing. Change the logging path "
-                            f'"{logging_path}" to something else to retrain the {self.get_formatted_model_name()} model.'
+                            f'"{logging_path}" to something else to retrain the {self.get_formatted_model_name()} '
+                            f'model.'
                         )
 
                     raise ValueError(value_error_message) from error

--- a/docs/source/examples/retrain_with_new_prediction_tags.rst
+++ b/docs/source/examples/retrain_with_new_prediction_tags.rst
@@ -69,3 +69,12 @@ Now let's test our fine-tuned model using the best checkpoint (default parameter
 .. code-block:: python
 
     address_parser.test(test_container, batch_size=256)
+
+
+Now let's see how we can reload our new AddressParser.
+When you retrain a model, at the end, we create a retrained checkpoint using the best checkpoint and also include some metadata for the reloading (the tags, the dimension, etc.). By defaults, the checkpoint is named `"retrain_modeltype_parser.ckpt"`.
+
+.. code-block:: python
+
+    retrain_model_path = os.path.join("checkpoints", "retrained_fasttext_address_parser.ckpt")
+    address_parser = AddressParser(path_to_retrained_model=retrain_model_path)

--- a/examples/retrain_with_new_prediction_tags.py
+++ b/examples/retrain_with_new_prediction_tags.py
@@ -60,3 +60,10 @@ address_parser.retrain(
     logging_path=logging_path,
     layers_to_freeze="seq2seq",
 )
+
+# Now let's see how we can reload our new AddressParser.
+# When you retrain a model, at the end, we create a retrained checkpoint using the best checkpoint
+# and also include some metadata for the reloading (the tags, the dimension, etc.).
+# By defaults, the checkpoint is named "retrain_modeltype_parser.ckpt".
+retrain_model_path = os.path.join("checkpoints", "retrained_fasttext_address_parser.ckpt")
+address_parser = AddressParser(path_to_retrained_model=retrain_model_path)

--- a/tests/cli/test_parse.py
+++ b/tests/cli/test_parse.py
@@ -25,6 +25,8 @@ from tests.tools import create_pickle_file, create_csv_file
 class ParseTests(PretrainedWeightsBase):
     @classmethod
     def setUpClass(cls):
+        super(ParseTests, cls).setUpClass()
+
         cls.prepare_pre_trained_weights()
 
     @pytest.fixture(autouse=True)

--- a/tests/cli/test_parse.py
+++ b/tests/cli/test_parse.py
@@ -7,7 +7,7 @@ import logging
 import os
 import unittest
 from tempfile import TemporaryDirectory
-from unittest import TestCase, skipIf
+from unittest import skipIf
 from unittest.mock import patch
 
 import pytest
@@ -18,10 +18,10 @@ from tests.parser.base import PretrainedWeightsBase
 from tests.tools import create_pickle_file, create_csv_file
 
 
-class ParseTests(TestCase, PretrainedWeightsBase):
+class ParseTests(PretrainedWeightsBase):
     @classmethod
     def setUpClass(cls):
-        cls.download_pre_trained_weights(cls)
+        cls.prepare_pre_trained_weights()
 
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, caplog):
@@ -284,8 +284,6 @@ class ParseTests(TestCase, PretrainedWeightsBase):
     )
     def test_ifPathToFakeRetrainModel_thenUseFakeRetrainModel(self):
         with self._caplog.at_level(logging.INFO):
-            # We use the default path to fasttext model as a "retrain model path"
-            path_to_retrained_model = os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "fasttext.ckpt")
             create_pickle_file(self.fake_data_path_pickle, predict_container=True)
 
             parse.main(
@@ -296,7 +294,7 @@ class ParseTests(TestCase, PretrainedWeightsBase):
                     "--device",
                     self.cpu_device,
                     "--path_to_retrained_model",
-                    path_to_retrained_model,
+                    self.path_to_retrain_fasttext,
                 ]
             )
 

--- a/tests/cli/test_parse.py
+++ b/tests/cli/test_parse.py
@@ -18,6 +18,10 @@ from tests.parser.base import PretrainedWeightsBase
 from tests.tools import create_pickle_file, create_csv_file
 
 
+@skipIf(
+    not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
+    "download of model too long for test in runner",
+)
 class ParseTests(PretrainedWeightsBase):
     @classmethod
     def setUpClass(cls):
@@ -54,10 +58,6 @@ class ParseTests(PretrainedWeightsBase):
     def tearDown(self) -> None:
         self.temp_dir_obj.cleanup()
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_cpu(self):
         create_pickle_file(self.fake_data_path_pickle, predict_container=True)
 
@@ -91,10 +91,6 @@ class ParseTests(PretrainedWeightsBase):
         export_path = generate_export_path(self.fake_data_path_pickle, self.pickle_p_export_filename)
         self.assertTrue(os.path.isfile(export_path))
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_logging(self):
         with self._caplog.at_level(logging.INFO):
             create_pickle_file(self.fake_data_path_pickle, predict_container=True)
@@ -120,10 +116,6 @@ class ParseTests(PretrainedWeightsBase):
         actual_second_message = self._caplog.records[1].message
         self.assertEqual(expected_second_message, actual_second_message)
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_no_logging(self):
         with self._caplog.at_level(logging.INFO):
             create_pickle_file(self.fake_data_path_pickle, predict_container=True)
@@ -157,10 +149,6 @@ class ParseTests(PretrainedWeightsBase):
         export_path = generate_export_path(self.fake_data_path_pickle, self.pickle_p_export_filename)
         self.assertTrue(os.path.isfile(export_path))
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_json(self):
         create_pickle_file(self.fake_data_path_pickle, predict_container=True)
 
@@ -177,10 +165,6 @@ class ParseTests(PretrainedWeightsBase):
         export_path = generate_export_path(self.fake_data_path_pickle, self.json_export_filename)
         self.assertTrue(os.path.isfile(export_path))
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_csv(self):
         create_csv_file(self.fake_data_path_csv, predict_container=True)
 
@@ -199,10 +183,6 @@ class ParseTests(PretrainedWeightsBase):
         export_path = generate_export_path(self.fake_data_path_csv, self.csv_export_filename)
         self.assertTrue(os.path.isfile(export_path))
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_integration_csv_separator(self):
         sep = ";"
         create_csv_file(self.fake_data_path_csv, predict_container=True, separator=sep)
@@ -224,10 +204,6 @@ class ParseTests(PretrainedWeightsBase):
         export_path = generate_export_path(self.fake_data_path_pickle, self.csv_export_filename)
         self.assertTrue(os.path.isfile(export_path))
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifIsCSVFile_noColumnName_raiseValueError(self):
         create_csv_file(self.fake_data_path_csv, predict_container=True)
 
@@ -242,10 +218,6 @@ class ParseTests(PretrainedWeightsBase):
                 ]
             )
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifIsNotSupportedFile_raiseValueError(self):
         create_csv_file(self.fake_data_path_csv, predict_container=True)
 
@@ -260,10 +232,6 @@ class ParseTests(PretrainedWeightsBase):
                 ]
             )
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifIsNotSupportedExportFile_raiseValueError(self):
         create_csv_file(self.fake_data_path_csv, predict_container=True)
 
@@ -278,10 +246,6 @@ class ParseTests(PretrainedWeightsBase):
                 ]
             )
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifPathToFakeRetrainModel_thenUseFakeRetrainModel(self):
         with self._caplog.at_level(logging.INFO):
             create_pickle_file(self.fake_data_path_pickle, predict_container=True)
@@ -304,10 +268,6 @@ class ParseTests(PretrainedWeightsBase):
         actual_first_message = self._caplog.records[0].message
         self.assertEqual(expected_first_message, actual_first_message)
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifPathToFastTextRetrainModel_thenUseFastTextRetrainModel(self):
         with self._caplog.at_level(logging.INFO):
             path_to_retrained_model = self.path_to_retrain_fasttext
@@ -331,10 +291,6 @@ class ParseTests(PretrainedWeightsBase):
         actual_first_message = self._caplog.records[0].message
         self.assertEqual(expected_first_message, actual_first_message)
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifPathToBPEmbRetrainModel_thenUseBPEmbRetrainModel(self):
         with self._caplog.at_level(logging.INFO):
             create_pickle_file(self.fake_data_path_pickle, predict_container=True)
@@ -357,10 +313,6 @@ class ParseTests(PretrainedWeightsBase):
         actual_first_message = self._caplog.records[2].message
         self.assertEqual(expected_first_message, actual_first_message)
 
-    @skipIf(
-        not os.path.exists(os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "cc.fr.300.bin")),
-        "download of model too long for test in runner",
-    )
     def test_ifCachePath_thenUseNewCachePath(self):
         create_pickle_file(self.fake_data_path_pickle, predict_container=True)
 

--- a/tests/cli/test_testing.py
+++ b/tests/cli/test_testing.py
@@ -25,7 +25,13 @@ class TestingTests(RetrainTestCase, PretrainedWeightsBase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestingTests, cls).setUpClass()
+        # Calling super does not seem to properly call each parent class setUpClass, thus
+        # the second setUpClass (PretrainedWeightsBase) is not call and make child setUpClass fail
+        # due to missing attribute.
+        # super(TestingTests, cls).setUpClass()
+        # This approach make it work by calling each setUpClass manually.
+        RetrainTestCase.setUpClass()
+        PretrainedWeightsBase.setUpClass()
 
         cls.prepare_pre_trained_weights()
 

--- a/tests/cli/test_testing.py
+++ b/tests/cli/test_testing.py
@@ -27,7 +27,7 @@ class TestingTests(RetrainTestCase, PretrainedWeightsBase):
     def setUpClass(cls):
         super(TestingTests, cls).setUpClass()
 
-        cls.download_pre_trained_weights(cls)
+        cls.prepare_pre_trained_weights()
 
         cls.a_fasttext_model_type = "fasttext"
         cls.a_fasttext_att_model_type = "fasttext-attention"
@@ -187,14 +187,11 @@ class TestingTests(RetrainTestCase, PretrainedWeightsBase):
 
     def test_ifPathToFakeRetrainModel_thenUseFakeRetrainModel(self):
         with self._caplog.at_level(logging.INFO):
-            # We use the default path to fasttext model as a "retrain model path"
-            path_to_retrained_model = os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "fasttext.ckpt")
-
             parser_params = [
                 self.a_fasttext_model_type,
                 self.a_train_pickle_dataset_path,
                 "--path_to_retrained_model",
-                path_to_retrained_model,
+                self.path_to_retrain_fasttext,
                 "--device",
                 self.cpu_device,
             ]

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -61,7 +61,7 @@ class PretrainedWeightsBase(CaptureOutputTestCase):
         cls.model_weights_temp_dir.cleanup()
 
 
-class AddressParserPredictTestCase(PretrainedWeightsBase):
+class AddressParserPredictTestCase(CaptureOutputTestCase):
     @classmethod
     def setUpClass(cls):
         cls.a_best_model_type = "best"
@@ -80,8 +80,6 @@ class AddressParserPredictTestCase(PretrainedWeightsBase):
         cls.a_street_number = "15"
 
         cls.a_logging_path = "data"
-
-        cls.prepare_pre_trained_weights()
 
     def setUp(self):
         # a prediction vector with real values
@@ -188,7 +186,6 @@ class AddressParserPredictTestCase(PretrainedWeightsBase):
         # to create the dir for the model and dump the prediction_tags.p if needed
         self.a_model_root_path = "model"
         os.makedirs(self.a_model_root_path, exist_ok=True)
-        self.a_model_path = self.path_to_retrain_fasttext
 
     def mock_predictions_vectors(self, model):
         returned_prediction_vectors = self.a_prediction_vector_for_a_complete_address

--- a/tests/parser/base.py
+++ b/tests/parser/base.py
@@ -20,8 +20,11 @@ from tests.base_capture_output import CaptureOutputTestCase
 
 class PretrainedWeightsBase(CaptureOutputTestCase):
     @classmethod
-    def prepare_pre_trained_weights(cls):
+    def setUpClass(cls) -> None:
         cls.model_weights_temp_dir = TemporaryDirectory()
+
+    @classmethod
+    def prepare_pre_trained_weights(cls):
         cls.fake_cache_path = os.path.join(cls.model_weights_temp_dir.name, "fake_cache")
 
         path_to_default_model = os.path.join(os.path.expanduser("~"), ".cache", "deepparse", "fasttext.ckpt")

--- a/tests/parser/integration/test_integration_reload_retrain_parser.py
+++ b/tests/parser/integration/test_integration_reload_retrain_parser.py
@@ -18,7 +18,7 @@ class AddressParserIntegrationReloadRetrainAPITest(AddressParserRetrainTestCase,
     @classmethod
     def setUpClass(cls):
         super(AddressParserIntegrationReloadRetrainAPITest, cls).setUpClass()
-        cls.download_pre_trained_weights(cls)
+        cls.prepare_pre_trained_weights()
 
     def test_integration_parsing_with_retrain_fasttext(self):
         model_type = "fasttext"
@@ -35,7 +35,7 @@ class AddressParserIntegrationReloadRetrainAPITest(AddressParserRetrainTestCase,
         self.assertEqual(model_type, address_parser.model_type)
 
     def test_integration_parsing_with_retrain_named_model(self):
-        model_type = "fasttext"  # Base architecture of the named model is a FastText
+        model_type = "bpemb"  # A model, could be fasttext if we update the model content in the model path
         path_to_retrained_model = self.path_to_named_model
 
         address_parser = AddressParser(model_type=model_type, path_to_retrained_model=path_to_retrained_model)

--- a/tests/parser/test_address_parser.py
+++ b/tests/parser/test_address_parser.py
@@ -75,6 +75,21 @@ class AddressParserTest(AddressParserPredictTestCase):
         cls.export_temp_dir_obj = TemporaryDirectory()
         cls.a_saving_dir_path = cls.export_temp_dir_obj.name
 
+        cls.a_model_path = os.path.join(cls.temp_dir_obj.name, "retrained_fasttext_address_parser.ckpt")
+
+        cls.create_fake_address_parser_checkpoint()
+
+    @classmethod
+    def create_fake_address_parser_checkpoint(cls):
+        checkpoint_weights = {
+            "address_tagger_model": [0, 0],
+            "model_type": "fasttext",
+            "named_parser": "PreTrainedFastTextAddressParser",
+        }
+
+        with open(cls.a_model_path, "wb") as file:
+            torch.save(checkpoint_weights, file)
+
     @classmethod
     def tearDownClass(cls) -> None:
         cls.temp_dir_obj.cleanup()

--- a/tests/parser/test_address_parser_retrain_api.py
+++ b/tests/parser/test_address_parser_retrain_api.py
@@ -1716,6 +1716,20 @@ class AddressParserRetrainTest(AddressParserPredictTestCase):
                     MagicMock(), train_ratio=0.8, batch_size=1, epochs=1, num_workers=num_workers_gt_0
                 )
 
+    def test_givenAnyModelWith_whenPathToTrainLeadToWrongCheckpoint_thenRaiseError(self):
+        # The dictionary does not include the minimal metadata of the name of the retrain address parser.
+        content_of_the_checkpoint = {"some_weights": [1, 2], "other_weights": [3, 4]}
+        a_path_to_retrained_model_with_missing_metadata = os.path.join(self.a_logging_path, "a_checkpoint.ckpt")
+        with open(a_path_to_retrained_model_with_missing_metadata, "wb") as file:
+            torch.save(content_of_the_checkpoint, file)
+
+        with self.assertRaises(RuntimeError):
+            AddressParser(
+                model_type=self.a_fasttext_model_type,
+                device=self.a_device,
+                path_to_retrained_model=a_path_to_retrained_model_with_missing_metadata,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/parser/test_address_parser_retrain_api.py
+++ b/tests/parser/test_address_parser_retrain_api.py
@@ -279,8 +279,10 @@ class AddressParserRetrainTest(AddressParserPredictTestCase):
             self.address_parser_retrain_call()
 
         expect_error_message = (
-            f"You are currently training a different fasttext version from the one in"
-            f" the {self.a_logging_path}. Verify version."
+            "You are currently retraining a different FastText AddressParser configuration "
+            "in the same directory as a previous retrained model. "
+            "The configurations must be different (number of tag, seq2seq dimensions, etc.). "
+            "The easiest thing to do is to change the saving directory to avoid colliding checkpoint."
         )
         try:
             self.address_parser_retrain_call()
@@ -320,9 +322,11 @@ class AddressParserRetrainTest(AddressParserPredictTestCase):
             self.address_parser_retrain_call()
 
         expect_error_message = (
-            f"You are currently training a bpemb in the directory {self.a_logging_path} where a "
-            f"different retrained fasttext is currently his. Thus, the loading of the model is "
-            f"failing. Change directory to retrain the bpemb."
+            "You are currently training a BPEmb in the directory "
+            f"{self.a_logging_path} where a different retrained "
+            f"fasttext model is currently his."
+            f" Thus, the loading of the model checkpoint is failing. Change the logging path "
+            f'"{self.a_logging_path}" to something else to retrain the BPEmb model.'
         )
         try:
             self.address_parser_retrain_call()

--- a/tests/parser/test_address_parser_retrain_api.py
+++ b/tests/parser/test_address_parser_retrain_api.py
@@ -18,7 +18,7 @@ from deepparse.errors import FastTextModelError
 from deepparse.metrics import nll_loss, accuracy
 from deepparse.parser import AddressParser
 from tests.parser.base import AddressParserPredictTestCase
-from tests.tools import BATCH_SIZE, ADataContainer, create_file
+from tests.tools import BATCH_SIZE, ADataContainer, create_file, create_fake_checkpoint
 
 
 class AddressParserRetrainTest(AddressParserPredictTestCase):
@@ -1717,11 +1717,8 @@ class AddressParserRetrainTest(AddressParserPredictTestCase):
                 )
 
     def test_givenAnyModelWith_whenPathToTrainLeadToWrongCheckpoint_thenRaiseError(self):
-        # The dictionary does not include the minimal metadata of the name of the retrain address parser.
-        content_of_the_checkpoint = {"some_weights": [1, 2], "other_weights": [3, 4]}
         a_path_to_retrained_model_with_missing_metadata = os.path.join(self.a_logging_path, "a_checkpoint.ckpt")
-        with open(a_path_to_retrained_model_with_missing_metadata, "wb") as file:
-            torch.save(content_of_the_checkpoint, file)
+        create_fake_checkpoint(path=a_path_to_retrained_model_with_missing_metadata, with_metadata=False)
 
         with self.assertRaises(RuntimeError):
             AddressParser(

--- a/tests/parser/test_tools.py
+++ b/tests/parser/test_tools.py
@@ -22,15 +22,14 @@ from deepparse.parser.tools import (
     handle_model_name,
     infer_model_type,
 )
-from tests.base_capture_output import CaptureOutputTestCase
 from tests.parser.base import PretrainedWeightsBase
 from tests.tools import create_file
 
 
-class ToolsTests(CaptureOutputTestCase, PretrainedWeightsBase):
+class ToolsTests(PretrainedWeightsBase):
     @classmethod
     def setUpClass(cls):
-        cls.download_pre_trained_weights(cls)
+        cls.prepare_pre_trained_weights()
 
     def setUp(self) -> None:
         self.a_seed = 42

--- a/tests/parser/test_tools.py
+++ b/tests/parser/test_tools.py
@@ -27,10 +27,6 @@ from tests.tools import create_file
 
 
 class ToolsTests(PretrainedWeightsBase):
-    @classmethod
-    def setUpClass(cls):
-        cls.prepare_pre_trained_weights()
-
     def setUp(self) -> None:
         self.a_seed = 42
         self.temp_dir_obj = TemporaryDirectory()
@@ -488,6 +484,8 @@ class ToolsTests(PretrainedWeightsBase):
         "download of model too long for test in runner",
     )
     def test_givenAModelTypeToInfer_whenRealRetrainFastText_thenReturnFastText(self):
+        self.prepare_pre_trained_weights()
+
         path_to_retrained_model = self.path_to_retrain_fasttext
         checkpoint_weights = torch.load(path_to_retrained_model, map_location="cpu")
         attention_mechanism = False
@@ -503,6 +501,8 @@ class ToolsTests(PretrainedWeightsBase):
         "download of model too long for test in runner",
     )
     def test_givenAModelTypeToInfer_whenRealRetrainBPEmb_thenReturnBPEmb(self):
+        self.prepare_pre_trained_weights()
+
         path_to_retrained_model = self.path_to_retrain_bpemb
         checkpoint_weights = torch.load(path_to_retrained_model, map_location="cpu")
         attention_mechanism = False

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -51,6 +51,15 @@ def create_pickle_file(path: str, number_of_data_points: int = 4, predict_contai
         pickle.dump(pickle_file_content, f)
 
 
+def create_fake_checkpoint(path: str, with_metadata: bool = True) -> None:
+    content_of_the_checkpoint = {"some_weights": [1, 2], "other_weights": [3, 4]}
+    if with_metadata:
+        content_of_the_checkpoint.update({"named_parser": "a_name"})
+
+    with open(path, "wb") as file:
+        torch.save(content_of_the_checkpoint, file)
+
+
 def create_csv_file(
     path: str,
     predict_container: bool = False,


### PR DESCRIPTION
Improve error handling when using a retrained model path with missing metadata (a poutyne ckpt instead of the final model).