### PR TITLE
Bug fix fasttext build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pybind11
+          python -m pip install --upgrade pip
           pip install -Ur requirements.txt
           pip install -Ur docs/requirements.txt
           pip install -e .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          pip install -U pybind11
           pip install -Ur requirements.txt
           pip install -Ur docs/requirements.txt
           pip install -e .

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pybind11
+          python -m pip install --upgrade pip
           pip install -Ur requirements.txt
           pip install -Ur styling_requirements.txt
           pip install -Ur tests/requirements.txt

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          pip install -U pybind11
           pip install -Ur requirements.txt
           pip install -Ur styling_requirements.txt
           pip install -Ur tests/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          pip install -U pybind11
           pip install -Ur requirements.txt
           pip install -Ur tests/requirements.txt
           python setup.py develop
@@ -38,6 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          pip install -U pybind11
           pip install -Ur requirements.txt
           pip install -Ur tests/requirements.txt
           python setup.py develop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pybind11
+          python -m pip install --upgrade pip
           pip install -Ur requirements.txt
           pip install -Ur tests/requirements.txt
           python setup.py develop
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          pip install -U pybind11
+          python -m pip install --upgrade pip
           pip install -Ur requirements.txt
           pip install -Ur tests/requirements.txt
           python setup.py develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,3 +322,6 @@
 - Improve error handling of `path_to_retrain_model`
 - Bug-fix pre-processor error
 - Add verbose override and improve verbosity handling in retrain
+- Bug-fix the broken FastText installation using `fasttext-wheel` instead of `fasttext` (
+  see [here](https://github.com/facebookresearch/fastText/issues/512#issuecomment-1534519551)
+  and [here](https://github.com/facebookresearch/fastText/pull/1292)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ testpaths = [
 
 [tool.pylint.ini_options]
 DJANGO_SETTINGS_MODULE = "settings"
+
+[build-system]
+requires = ["setuptools", "wheel", "pybind11"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pymagnitude-light
 colorama>=0.4.3
 poutyne
 gensim>=4.2.0
-fasttext
+fasttext-wheel
 pandas
 urllib3
 cloudpathlib[s3, gs, azure]


### PR DESCRIPTION
Bug-fix the broken FastText installation using `fasttext-wheel` instead of `fasttext` (see [here](https://github.com/facebookresearch/fastText/issues/512#issuecomment-1534519551) and [here](https://github.com/facebookresearch/fastText/pull/1292)).