### PR TITLE
fasttext build : Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ def main():
             "bpemb",
             "gensim>=4.0.0",
             "requests",
-            "fasttext",
+            "fasttext-wheel",
             "pymagnitude-light",
             "poutyne",
             "pandas",


### PR DESCRIPTION
change fasttext requirements to fasttext-wheel

This PR fixe issue #196 

Fasttext build fails and change to fasttext-wheel has been made in requirements but not in setup.py

Fix fasttext to fasttext-wheel in setup.py