### PR TITLE
Add 3.10 and 3.11 in windows tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9" ] # pip install requirements fail on 3.10 and 3.11 because of Fasttext
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ] # pip install requirements fail on 3.10 and 3.11 because of Fasttext
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ] # pip install requirements fail on 3.10 and 3.11 because of Fasttext
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fix missing Python 3.10 and 3.11 for Windows test due to fasttext by using Fasttext-wheel.
