### PR TITLE
Adding Gensim last update for support 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests
 pymagnitude-light
 colorama>=0.4.3
 poutyne
-gensim>=4.2.0
+gensim@ git+https://github.com/piskvorky/gensim.git@da2f388
 fasttext-wheel
 pandas
 urllib3


### PR DESCRIPTION
Adding the last stable commit of gensim for support Python 3.12, I wrote a similar problem here.
https://blog.techbend.io/overcoming-the-hazm-compatibility-challenge-with-python-312

This PR fixes issue #220 


