### PR TITLE
Remove numpy<2.0.0 version cap

### DIFF
--- a/deepparse/embeddings_models/bpemb_embeddings_model.py
+++ b/deepparse/embeddings_models/bpemb_embeddings_model.py
@@ -3,7 +3,7 @@ import warnings
 from pathlib import Path
 
 import requests
-from numpy.core.multiarray import ndarray
+from numpy import ndarray
 from urllib3.exceptions import InsecureRequestWarning
 
 from ..bpemb_url_bug_fix import BPEmbBaseURLWrapperBugFix

--- a/deepparse/embeddings_models/embeddings_model.py
+++ b/deepparse/embeddings_models/embeddings_model.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from numpy.core.multiarray import ndarray
+from numpy import ndarray
 
 
 class EmbeddingsModel(ABC):

--- a/deepparse/embeddings_models/fasttext_embeddings_model.py
+++ b/deepparse/embeddings_models/fasttext_embeddings_model.py
@@ -1,7 +1,7 @@
 import platform
 
 from gensim.models.fasttext import load_facebook_vectors
-from numpy.core.multiarray import ndarray
+from numpy import ndarray
 
 from .. import load_fasttext_embeddings
 from .embeddings_model import EmbeddingsModel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 bpemb
-numpy<2.0.0
+numpy
 scipy
 requests
 pymagnitude-light

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def main():
         ],
         packages=packages,
         install_requires=[
-            "numpy<2.0.0",
+            "numpy",
             "torch",
             "bpemb",
             "scipy",


### PR DESCRIPTION
## Summary
- Replace private `numpy.core.multiarray.ndarray` imports with the public `numpy.ndarray` API in 3 embeddings model files
- Remove the `<2.0.0` version constraint from `setup.py` and `requirements.txt`

The private import path `numpy.core.multiarray` changed in numpy 2.0, which was the only incompatibility preventing the upgrade. No other deprecated numpy APIs are used in the codebase.

Closes #241

## Test plan
- [x] All existing tests pass locally (470 passed, 250 skipped)
- [x] Black formatting passes
- [ ] CI passes on Python 3.10 and 3.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)