### PR TITLE
Add pip-audit workflow for dependency vulnerability scanning

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,27 @@
+name: Pip Audit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install deepparse and pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[all]
+          pip install pip-audit
+      - name: Run pip-audit
+        run: |
+          pip-audit --strict --desc


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pip-audit.yml` that runs `pip-audit --strict --desc` on every push/PR to `main` and weekly (Monday 06:00 UTC).
- Installs `.[all]` so both runtime and dev/optional dependencies are audited.
- Local run on current `main` reported no known vulnerabilities.

## Test plan
- [ ] CI job "Pip Audit" runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)