### PR TITLE
Fix greetings workflow failing on all PRs

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Thank you for you interest in improving Deepparse."
-          pr-message: "Thank you for you interest in improving Deepparse."
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: "Thank you for your interest in improving Deepparse."
+          pr_message: "Thank you for your interest in improving Deepparse."


### PR DESCRIPTION
## Problème

Le job \`greeting\` échouait sur **toutes** les PRs (visible sur les 5 PRs Dependabot récentes) avec :

\`\`\`
Error: Input required and not supplied: issue_message
##[warning]Unexpected input(s) 'repo-token', 'issue-message', 'pr-message',
valid inputs are ['issue_message', 'pr_message', 'repo_token']
\`\`\`

## Cause

\`actions/first-interaction@v3\` a renommé ses inputs de kebab-case vers snake_case :
- \`repo-token\` → \`repo_token\`
- \`issue-message\` → \`issue_message\`
- \`pr-message\` → \`pr_message\`

Le workflow utilisait encore les anciens noms.

## Correctif

- Renommage des trois inputs vers le format snake_case attendu par la v3.
- Correction du typo "you interest" → "your interest" dans les messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)