### PR TITLE
Fix remaining kebab-case input in greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: "Thank you for your interest in improving Deepparse."
           pr_message: "Thank you for your interest in improving Deepparse."


### PR DESCRIPTION
Complète le correctif du job \`greeting\` sur la branche \`dev\`.

\`dev\` avait déjà \`issue_message\`/\`pr_message\` corrigés mais gardait \`repo-token\` (kebab-case), alors que \`actions/first-interaction@v3\` attend \`repo_token\`. Le job échouait donc encore.

Pendant : \`repo-token\` → \`repo_token\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)