### PR TITLE
ci: run pip-audit on dev branch

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,27 @@
+name: Pip Audit
+
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
+    branches: [ main, dev ]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install deepparse and pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[all]
+          pip install pip-audit
+      - name: Run pip-audit
+        run: |
+          pip-audit --desc --skip-editable


### PR DESCRIPTION
## Contexte

Audit sécurité des dépendances du 2026-06-01. Aucune dépendance vulnérable détectée sur `main` (fastapi 0.134.0 OK via OSV, pip-audit vert sur l'arbre `.[all]` résolu).

## Problème structurel

Le workflow `pip-audit.yml` n'existait que sur `main` et ne tournait jamais contre `dev`, alors que les PRs Dependabot et le développement actif y atterrissent. Une dépendance vulnérable introduite sur `dev` passerait inaperçue jusqu'au merge vers `main`.

## Correctif

Ajoute `pip-audit.yml` sur `dev` avec `main` **et** `dev` dans les déclencheurs `push`/`pull_request`, plus le scan hebdomadaire planifié. Les bumps de dépendances sont ainsi scannés avant d'atteindre une release.

Source : OSV.dev via baseline-dep-scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)