### PR TITLE
fix(dataset): flag partially empty tag sets in training validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,3 +413,6 @@
 - Replace `Union[X, None]` type hints with PEP 604 `X | None` pipe syntax (Python 3.10+).
 - Fix CLI `retrain` command silently ignoring the `--prediction_tags` argument.
 - Remove dead code in CLI `retrain` (`parser_args.update` on unused dict) and simplify `handle_prediction_tags()`.
+- Fix training dataset validation not flagging a partially empty tag set: `_empty_tags` used `all` instead of
+  `any`, so a single empty tag list (e.g. `("an address", [])`) was masked and reported through the generic
+  length-mismatch error instead of the clearer "Some tags data points are empty." error.

--- a/deepparse/dataset_container/dataset_container.py
+++ b/deepparse/dataset_container/dataset_container.py
@@ -148,7 +148,7 @@ class DatasetContainer(Dataset, ABC):
 
     def _data_is_list_of_tuple(self) -> bool:
         """
-        Return true if one of the elements in the dataset is not a tuple.
+        Return true only if every element in the dataset is a tuple.
         """
         return all(isinstance(data, tuple) for data in self.data)
 
@@ -156,7 +156,7 @@ class DatasetContainer(Dataset, ABC):
         """
         Return true if one of the tag sets is empty.
         """
-        return all(len(data[1]) == 0 for data in self.data)
+        return any(len(data[1]) == 0 for data in self.data)
 
     def _data_tags_is_same_len_then_address(self) -> bool:
         """

--- a/tests/dataset_container/test_dataset_container.py
+++ b/tests/dataset_container/test_dataset_container.py
@@ -129,17 +129,27 @@ class DatasetContainerTest(TestCase):
             ADatasetContainer(some_invalid_data)
 
     def test_when_empty_tags_set_then_raise_data_error(self):
+        # A single empty tag set among valid ones must be detected (any, not all). We assert on the
+        # specific message so the test fails if the empty-tags check is weakened to ``all`` (which would
+        # let the generic length-mismatch check raise a different, misleading error instead).
         some_invalid_data = [("An address", [1, 0]), ("another address", []), ("A last address", [3, 4, 0])]
-        with self.assertRaises(DataError):
+        with self.assertRaisesRegex(DataError, "Some tags data points are empty."):
+            ADatasetContainer(some_invalid_data)
+
+    def test_when_all_tags_sets_empty_then_raise_data_error(self):
+        # The empty-tags check must also fire when every tag set is empty.
+        some_invalid_data = [("An address", []), ("another address", []), ("A last address", [])]
+        with self.assertRaisesRegex(DataError, "Some tags data points are empty."):
             ADatasetContainer(some_invalid_data)
 
     def test_when_tags_set_not_same_len_as_address_then_raise_data_error(self):
+        # Tags are non-empty here, so the empty-tags check must NOT fire; the length-mismatch check must.
         some_invalid_data = [("An address", [1, 0]), ("another address", [1]), ("A last address", [3, 4, 0])]
-        with self.assertRaises(DataError):
+        with self.assertRaisesRegex(DataError, "not the same length"):
             ADatasetContainer(some_invalid_data)
 
         some_invalid_data = [("An address", [1, 0]), ("another address", [1, 2, 4]), ("A last address", [3, 4, 0])]
-        with self.assertRaises(DataError):
+        with self.assertRaisesRegex(DataError, "not the same length"):
             ADatasetContainer(some_invalid_data)
 
     def test_when_predict_container_when_data_is_not_a_list_raise_type_error(self):


### PR DESCRIPTION
## Bug

`DatasetContainer._empty_tags()` utilisait `all()` au lieu de `any()`. Conséquence : un dataset d'entraînement contenant **un seul** tag set vide (ex. `("an address", [])`) n'était pas détecté par le check dédié. La donnée levait quand même une `DataError`, mais via le check générique de longueur, avec un message trompeur :

> Some addresses (whitespace-split) and the tags associated with them are not the same length.

au lieu du message clair attendu :

> Some tags data points are empty.

La docstring de la méthode (« Return true if one of the tag sets is empty ») confirme que l'intention était `any`.

## Correctif

- `_empty_tags` : `all()` → `any()`.
- Docstring inversée de `_data_is_list_of_tuple` corrigée (la logique, elle, était correcte).

## Tests

- `test_when_empty_tags_set_then_raise_data_error` : passait de `assertRaises(DataError)` (bidon : restait vert même si on supprimait le code testé) à `assertRaisesRegex(..., "Some tags data points are empty.")`. Validation par mutation : réintroduire `all()` rend ce test rouge.
- `test_when_tags_set_not_same_len_as_address...` : assertion sur le message distinct `"not the same length"` pour séparer les deux gardes.
- Ajout `test_when_all_tags_sets_empty_then_raise_data_error` (cas tous-tags-vides).

## Validation locale

483 passed, 251 skipped (`TEST_LEVEL=unit`), pylint 10.00/10, black propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)