### PR TITLE
docs(readme): fix broken Zenodo DOI badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [![pr welcome](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?)](https://img.shields.io/badge/PR-Welcome-%23FF8300.svg?)
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](http://www.gnu.org/licenses/lgpl-3.0)
-[![DOI](https://zenodo.org/badge/276474742.svg)](https://zenodo.org/badge/latestdoi/276474742)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7010740.svg)](https://doi.org/10.5281/zenodo.7010740)
 [![Hugging Face Download](https://img.shields.io/badge/Hugging%20Face-FFD21E?logo=huggingface&logoColor=000)](https://huggingface.co/deepparse)
 
 [![Download](https://img.shields.io/badge/Download%20Dataset-blue?style=for-the-badge&logo=download)](https://github.com/GRAAL-Research/deepparse-address-data)


### PR DESCRIPTION
## Problème

Le badge DOI du README utilisait les endpoints legacy d'intégration GitHub de Zenodo :

\`\`\`
[![DOI](https://zenodo.org/badge/276474742.svg)](https://zenodo.org/badge/latestdoi/276474742)
\`\`\`

Ces URLs (`/badge/<id>.svg` et `/badge/latestdoi/<id>`) sont dépréciées par Zenodo ; elles ne fonctionnent que par redirection et sont souvent non rendues par le proxy d'images de GitHub.

## Correctif

Passage aux URLs canoniques basées sur le **concept DOI** `10.5281/zenodo.7010740` (résout toujours vers la dernière version) :

\`\`\`
[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7010740.svg)](https://doi.org/10.5281/zenodo.7010740)
\`\`\`

Vérifié : le SVG répond `200 image/svg+xml` directement, le lien `doi.org` redirige vers le record Zenodo concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)