### PR TITLE
fix: address multiple bugs found during code audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,3 +416,16 @@
 - Fix training dataset validation not flagging a partially empty tag set: `_empty_tags` used `all` instead of
   `any`, so a single empty tag list (e.g. `("an address", [])`) was masked and reported through the generic
   length-mismatch error instead of the clearer "Some tags data points are empty." error.
+- Fix `extract_package_version` reading `package.version.__version__`, which no longer exists in Poutyne >= 1.18
+  and broke `retrain` with an `AttributeError`. It now reads the standard `package.__version__`.
+- Fix the fine-tuned weights loader (`ModelLoader.load_weights`) always returning `None` as the model version:
+  the version was read from the inner state dict instead of the checkpoint metadata.
+- Fix `retrain` silently swallowing a genuine training `RuntimeError` (it inspected the current working directory
+  instead of the logging path); the error is now re-raised when there is no checkpoint collision.
+- Fix the parser mutating a caller-provided `pre_processors` list, which accumulated duplicate pre-processors
+  when the same list was reused across calls.
+- Fix CLI export-format detection matching the extension as a substring anywhere in the file name
+  (e.g. `report.pdf` treated as pickle); it now checks the real file extension.
+- Fix CLI attention-model handling using `str.strip("attention")` (a character set) to drop the `-attention`
+  suffix; it now uses `removesuffix("-attention")`.
+- Remove a no-op `self.model.state_dict()` call in `save_address_parser_weights`.

--- a/deepparse/cli/tools.py
+++ b/deepparse/cli/tools.py
@@ -29,7 +29,7 @@ def is_csv_path(export_file_name: str) -> bool:
         Either or not, the path is a CSV file extension.
     """
 
-    return ".csv" in export_file_name
+    return os.path.splitext(export_file_name)[1].lower() == ".csv"
 
 
 def is_pickle_path(export_file_name: str) -> bool:
@@ -42,7 +42,7 @@ def is_pickle_path(export_file_name: str) -> bool:
     Return:
         Either or not, the path is a pickle file extension.
     """
-    return ".p" in export_file_name or ".pickle" in export_file_name or ".pckl" in export_file_name
+    return os.path.splitext(export_file_name)[1].lower() in (".p", ".pickle", ".pckl")
 
 
 def is_json_path(export_file_name: str) -> bool:
@@ -55,7 +55,7 @@ def is_json_path(export_file_name: str) -> bool:
     Return:
         Either or not, the path is a json file extension.
     """
-    return ".json" in export_file_name
+    return os.path.splitext(export_file_name)[1].lower() == ".json"
 
 
 def to_csv(parsed_addresses: FormattedParsedAddress | List[FormattedParsedAddress], export_path: str, sep: str) -> None:
@@ -150,7 +150,7 @@ def attention_model_type_handling(parsing_model) -> Dict:
     parser_args_update_args = {}
     if "-attention" in parsing_model:
         parser_args_update_args.update({"attention_mechanism": True})
-        parsing_model = parsing_model.strip("attention").strip("-")
+        parsing_model = parsing_model.removesuffix("-attention")
     parser_args_update_args.update({"model_type": parsing_model})
     return parser_args_update_args
 

--- a/deepparse/network/model_loader.py
+++ b/deepparse/network/model_loader.py
@@ -58,13 +58,12 @@ class ModelLoader:
             representing the model's version.
 
         """
-        all_layers_params = handle_weights_upload(path_to_model_to_upload=path_to_model_torch_archive, device=device)
+        checkpoint_weights = handle_weights_upload(path_to_model_to_upload=path_to_model_torch_archive, device=device)
 
-        # All the time, our torch archive includes meta-data along with the model weights.
-        all_layers_params = all_layers_params.get("address_tagger_model")
+        # All the time, our torch archive includes meta-data along with the model weights. We read the version
+        # from the full checkpoint before extracting the state dict (the state dict itself has no "version" key).
+        version = checkpoint_weights.get("version")
 
-        model.load_state_dict(all_layers_params)
-
-        version = all_layers_params.get("version")
+        model.load_state_dict(checkpoint_weights.get("address_tagger_model"))
 
         return model, version

--- a/deepparse/parser/address_parser.py
+++ b/deepparse/parser/address_parser.py
@@ -436,11 +436,13 @@ class AddressParser:
             # Default pre_processing setup.
             pre_processors = [coma_cleaning, lower_cleaning, trailing_whitespace_cleaning, double_whitespaces_cleaning]
         else:
-            # We add, at the end, a lower casing cleaning pre-processor.
-            pre_processors.append(lower_cleaning)
+            # We add, at the end, a lower casing cleaning pre-processor. We build a new list rather than mutating
+            # the caller's list, otherwise reusing the same list across calls would accumulate duplicate
+            # pre-processors.
+            pre_processors = [*pre_processors, lower_cleaning]
 
         if with_hyphen_split:
-            pre_processors.append(hyphen_cleaning)
+            pre_processors = [*pre_processors, hyphen_cleaning]
 
         self.pre_processors = PreProcessorList(pre_processors)
         clean_addresses = self.pre_processors.apply(addresses_to_parse)
@@ -815,90 +817,87 @@ class AddressParser:
                 verbose=verbose,
             )
         except RuntimeError as error:
-            list_of_file_path = os.listdir(path=".")
-            if list_of_file_path:
-                if pretrained_parser_in_directory(logging_path):
-                    # Mean we might already have a checkpoint in the training directory
-                    files_in_directory = get_files_in_directory(logging_path)
-                    retrained_address_parser_in_directory = get_address_parser_in_directory(files_in_directory)[
-                        0
-                    ].split("_")[1]
-                    if self.model_type == retrained_address_parser_in_directory:
-                        value_error_message = (
-                            f"You are currently retraining a different {self.get_formatted_model_name()} AddressParser "
-                            f"configuration in the same directory as a previous retrained model. "
-                            "The configurations must be different (number of tag, seq2seq dimensions, etc.). "
-                            "The easiest thing to do is to change the saving directory to avoid colliding checkpoint."
-                        )
-                    else:
-                        value_error_message = (
-                            f"You are currently training a {self.get_formatted_model_name()} in the directory "
-                            f"{logging_path} where a different retrained "
-                            f"{retrained_address_parser_in_directory} model is currently his. "
-                            f"Thus, the loading of the model checkpoint is failing. Change the logging path "
-                            f'"{logging_path}" to something else to retrain the {self.get_formatted_model_name()} '
-                            f'model.'
-                        )
-
-                    raise ValueError(value_error_message) from error
-            else:
-                raise RuntimeError(error.args[0]) from error
-        else:
-            file_name = (
-                name_of_the_retrain_parser + ".ckpt"
-                if name_of_the_retrain_parser is not None
-                else f"retrained_{self.model_type}_address_parser.ckpt"
-            )
-            file_path = os.path.join(logging_path, file_name)
-
-            self.version = "Finetuned_" + self.version
-            torch_save = {
-                "address_tagger_model": exp.model.network.state_dict(),
-                "model_type": self.model_type,
-                "version": self.version,
-            }
-
-            if seq2seq_params is not None:
-                # Means we have changed the seq2seq params
-                torch_save.update({"seq2seq_params": seq2seq_params})
-            if prediction_tags is not None:
-                #  Means we have changed the prediction tags
-                torch_save.update({"prediction_tags": prediction_tags})
-
-            torch_save.update(
-                {
-                    "named_parser": (
-                        name_of_the_retrain_parser
-                        if name_of_the_retrain_parser is not None
-                        else self._formatted_named_parser_name(prediction_tags, seq2seq_params, layers_to_freeze)
+            if pretrained_parser_in_directory(logging_path):
+                # We might already have a checkpoint of a different configuration in the training directory.
+                files_in_directory = get_files_in_directory(logging_path)
+                retrained_address_parser_in_directory = get_address_parser_in_directory(files_in_directory)[0].split(
+                    "_"
+                )[1]
+                if self.model_type == retrained_address_parser_in_directory:
+                    value_error_message = (
+                        f"You are currently retraining a different {self.get_formatted_model_name()} AddressParser "
+                        f"configuration in the same directory as a previous retrained model. "
+                        "The configurations must be different (number of tag, seq2seq dimensions, etc.). "
+                        "The easiest thing to do is to change the saving directory to avoid colliding checkpoint."
                     )
-                }
-            )
+                else:
+                    value_error_message = (
+                        f"You are currently training a {self.get_formatted_model_name()} in the directory "
+                        f"{logging_path} where a different retrained "
+                        f"{retrained_address_parser_in_directory} model is currently his. "
+                        f"Thus, the loading of the model checkpoint is failing. Change the logging path "
+                        f'"{logging_path}" to something else to retrain the {self.get_formatted_model_name()} '
+                        f'model.'
+                    )
 
-            if isinstance(file_path, S3Path):
-                # To handle CloudPath path_to_model_weights
-                try:
-                    with file_path.open("wb") as file:
-                        torch.save(torch_save, file)
-                except FileNotFoundError as error:
-                    raise FileNotFoundError("The file in the S3 bucket was not found.") from error
+                raise ValueError(value_error_message) from error
+            # Otherwise the failure is a genuine training error; re-raise it instead of swallowing it.
+            raise
+        file_name = (
+            name_of_the_retrain_parser + ".ckpt"
+            if name_of_the_retrain_parser is not None
+            else f"retrained_{self.model_type}_address_parser.ckpt"
+        )
+        file_path = os.path.join(logging_path, file_name)
 
-            elif "s3://" in file_path:
-                file_path = CloudPath(file_path)
-                try:
-                    with file_path.open("wb") as file:
-                        torch.save(torch_save, file)
-                except FileNotFoundError as error:
-                    raise FileNotFoundError("The file in the S3 bucket was not found.") from error
-            else:
-                try:
-                    torch.save(torch_save, file_path)
-                except FileNotFoundError as error:
-                    if "s3" in file_path or "//" in file_path or ":" in file_path:
-                        raise FileNotFoundError(
-                            "Are You trying to use an AWS S3 URI? If so path needs to start with s3://."
-                        ) from error
-            return train_res
+        self.version = "Finetuned_" + self.version
+        torch_save = {
+            "address_tagger_model": exp.model.network.state_dict(),
+            "model_type": self.model_type,
+            "version": self.version,
+        }
+
+        if seq2seq_params is not None:
+            # Means we have changed the seq2seq params
+            torch_save.update({"seq2seq_params": seq2seq_params})
+        if prediction_tags is not None:
+            #  Means we have changed the prediction tags
+            torch_save.update({"prediction_tags": prediction_tags})
+
+        torch_save.update(
+            {
+                "named_parser": (
+                    name_of_the_retrain_parser
+                    if name_of_the_retrain_parser is not None
+                    else self._formatted_named_parser_name(prediction_tags, seq2seq_params, layers_to_freeze)
+                )
+            }
+        )
+
+        if isinstance(file_path, S3Path):
+            # To handle CloudPath path_to_model_weights
+            try:
+                with file_path.open("wb") as file:
+                    torch.save(torch_save, file)
+            except FileNotFoundError as error:
+                raise FileNotFoundError("The file in the S3 bucket was not found.") from error
+
+        elif "s3://" in file_path:
+            file_path = CloudPath(file_path)
+            try:
+                with file_path.open("wb") as file:
+                    torch.save(torch_save, file)
+            except FileNotFoundError as error:
+                raise FileNotFoundError("The file in the S3 bucket was not found.") from error
+        else:
+            try:
+                torch.save(torch_save, file_path)
+            except FileNotFoundError as error:
+                if "s3" in file_path or "//" in file_path or ":" in file_path:
+                    raise FileNotFoundError(
+                        "Are You trying to use an AWS S3 URI? If so path needs to start with s3://."
+                    ) from error
+        return train_res
 
     def test(
         self,
@@ -1039,8 +1038,6 @@ class AddressParser:
                 address_parser.save_address_parser_weights(a_path)
 
         """
-        self.model.state_dict()
-
         torch.save(self.model.state_dict(), file_path)
 
     def _fill_tagged_addresses_components(

--- a/deepparse/validations.py
+++ b/deepparse/validations.py
@@ -14,7 +14,7 @@ def extract_package_version(package) -> str:
     """
     Handle the retrieval of a Python package's major and minor version parts.
     """
-    full_version = package.version.__version__
+    full_version = package.__version__
     components_parts = full_version.split(".")
     major = components_parts[0]
     minor = components_parts[1]

--- a/tests/cli/test_tools.py
+++ b/tests/cli/test_tools.py
@@ -118,6 +118,14 @@ class ToolsTest(TestCase):
 
         self.assertFalse(is_pickle_path(not_a_pickle_path))
 
+    def test_givenMisleadingSubstringPaths_whenCheckingExtension_thenOnlyTheRealExtensionMatches(self):
+        # These names contain ".p"/".csv"/".json" as a substring that is NOT the actual extension. The
+        # extension check must look at the real suffix only, not a substring anywhere in the name.
+        self.assertFalse(is_pickle_path("report.pdf"))  # ".p" appears in ".pdf"
+        self.assertFalse(is_csv_path("archive.csv.bak"))  # ".csv" is not the suffix
+        self.assertTrue(is_json_path("data.pkg.json"))  # real suffix is .json
+        self.assertFalse(is_pickle_path("data.pkg.json"))  # must not be classified as pickle via ".p" in ".pkg"
+
     def test_givenJSONPath_whenJSONPath_returnTrue(self):
         a_json_path = "a_path.json"
 
@@ -290,10 +298,13 @@ class ToolsTest(TestCase):
         a_att_parsing_model = "fasttext-attention"
         actual_update_args = attention_model_type_handling(a_att_parsing_model)
         self.assertTrue(actual_update_args.get("attention_mechanism"))
+        # The "-attention" suffix must be removed cleanly without truncating the base model name.
+        self.assertEqual(actual_update_args.get("model_type"), "fasttext")
 
         a_att_parsing_model = "bpemb-attention"
         actual_update_args = attention_model_type_handling(a_att_parsing_model)
         self.assertTrue(actual_update_args.get("attention_mechanism"))
+        self.assertEqual(actual_update_args.get("model_type"), "bpemb")
 
     def test_givenNotAnAttModel_whenHandlingAttentionModelType_returnFalse(self):
         not_a_att_parsing_model = "fasttext"

--- a/tests/network/test_model_loader.py
+++ b/tests/network/test_model_loader.py
@@ -1,0 +1,51 @@
+# Since we use patch to mock the weights upload, we skip the unused argument error.
+# pylint: disable=unused-argument
+
+import unittest
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from deepparse.network import ModelLoader
+
+
+class ModelLoaderLoadWeightsTest(TestCase):
+    def setUp(self) -> None:
+        self.a_cache_dir = "a/cache/dir"
+        self.a_path = "a/path/to/retrained_model.ckpt"
+        self.a_device = "cpu"
+        self.a_version = "Finetuned_a_version"
+        self.a_state_dict = {"layer.weight": 0}
+        # The torch archive always wraps the weights with metadata at the top level.
+        self.a_checkpoint = {
+            "address_tagger_model": self.a_state_dict,
+            "model_type": "fasttext",
+            "version": self.a_version,
+        }
+
+    @patch("deepparse.network.model_loader.handle_weights_upload")
+    def test_givenACheckpoint_whenLoadWeights_thenReturnsTheCheckpointVersion(self, weights_upload_mock):
+        # The version lives at the top level of the checkpoint, not inside the state dict. Reading it after
+        # extracting the state dict (the previous bug) would always yield None.
+        weights_upload_mock.return_value = self.a_checkpoint
+        model_mock = MagicMock()
+
+        _, actual_version = ModelLoader(cache_dir=self.a_cache_dir).load_weights(
+            model=model_mock, path_to_model_torch_archive=self.a_path, device=self.a_device
+        )
+
+        self.assertEqual(actual_version, self.a_version)
+
+    @patch("deepparse.network.model_loader.handle_weights_upload")
+    def test_givenACheckpoint_whenLoadWeights_thenLoadsTheInnerStateDictIntoTheModel(self, weights_upload_mock):
+        weights_upload_mock.return_value = self.a_checkpoint
+        model_mock = MagicMock()
+
+        ModelLoader(cache_dir=self.a_cache_dir).load_weights(
+            model=model_mock, path_to_model_torch_archive=self.a_path, device=self.a_device
+        )
+
+        model_mock.load_state_dict.assert_called_once_with(self.a_state_dict)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/parser/test_address_parser_retrain_api.py
+++ b/tests/parser/test_address_parser_retrain_api.py
@@ -300,6 +300,43 @@ class AddressParserRetrainTest(AddressParserPredictTestCase):
         except RuntimeError as actual_error_message:
             self.assertEqual(actual_error_message.args[0], expect_error_message)
 
+    @patch("deepparse.parser.address_parser.torch.save")
+    @patch(
+        "deepparse.parser.address_parser.Experiment",
+        **{"return_value.train.side_effect": RuntimeError("Error during training")},
+    )
+    @patch("deepparse.parser.address_parser.SGD")
+    @patch("deepparse.parser.address_parser.ModelFactory")
+    @patch("deepparse.parser.address_parser.EmbeddingsModelFactory")
+    @patch("deepparse.parser.address_parser.VectorizerFactory")
+    @patch("deepparse.parser.address_parser.DataProcessorFactory")
+    @patch("deepparse.parser.address_parser.DataPadder")
+    def test_givenNoCheckpointInLoggingPath_whenRetrainRaisesRuntimeError_thenReRaiseInsteadOfSwallowing(
+        self,
+        data_padder_mock,
+        data_processor_factory_mock,
+        vectorizer_factory_mock,
+        embeddings_factory_mock,
+        model_factory_mock,
+        optimizer_mock,
+        experiment_mock,
+        torch_save_mock,
+    ):
+        # The logging path holds no previous checkpoint, so there is no configuration collision. A genuine
+        # training RuntimeError must be re-raised, not silently swallowed. (The previous implementation
+        # inspected the current working directory instead of the logging path and swallowed the error when
+        # the cwd happened to be non-empty.) We do NOT populate the directory and do NOT mock os.listdir.
+        model_factory_mock().create.return_value = self.model_mock, self.a_model_version
+
+        self.address_parser = AddressParser(
+            model_type=self.a_best_model_type,
+            device=self.a_device,
+            verbose=self.verbose,
+        )
+
+        with self.assertRaises(RuntimeError):
+            self.address_parser_retrain_call()
+
     @patch("deepparse.parser.address_parser.Experiment")
     @patch("deepparse.parser.address_parser.ModelFactory")
     @patch("deepparse.parser.address_parser.EmbeddingsModelFactory")

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -37,7 +37,7 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_1_givenHandlePoutyneVersion_thenReturnVersion1_1(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1.1"
+        poutyne_mock.__version__ = "1.1.1"
 
         actual = extract_package_version(package=poutyne_mock)
         expected = "1.1"
@@ -45,7 +45,7 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_1_1_givenHandlePoutyneVersion_thenReturnVersion1_1(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1.1.1"
+        poutyne_mock.__version__ = "1.1.1.1"
 
         actual = extract_package_version(package=poutyne_mock)
         expected = "1.1"
@@ -53,7 +53,7 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_dev_givenHandlePoutyneVersion_thenReturnVersion1_1(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1.dev1+81b3c7b"
+        poutyne_mock.__version__ = "1.1.dev1+81b3c7b"
 
         actual = extract_package_version(package=poutyne_mock)
         expected = "1.1"
@@ -61,7 +61,7 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_1_dev_givenHandlePoutyneVersion_thenReturnVersion1_1(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1.dev1+81b3c7b"
+        poutyne_mock.__version__ = "1.1.dev1+81b3c7b"
 
         actual = extract_package_version(package=poutyne_mock)
         expected = "1.1"
@@ -69,7 +69,7 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_2_givenHandlePoutyneVersion_thenReturnVersion1_2(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.2"
+        poutyne_mock.__version__ = "1.2"
 
         actual = extract_package_version(package=poutyne_mock)
         expected = "1.2"
@@ -77,63 +77,63 @@ class ValidationsTests(CaptureOutputTestCase, FileCreationTestCase):
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_2_givenValidPoutyneVersion_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.2"
+        poutyne_mock.__version__ = "1.2"
 
         actual = valid_poutyne_version()
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_2_dev_givenValidPoutyneVersion_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.2.dev1+81b3c7b"
+        poutyne_mock.__version__ = "1.2.dev1+81b3c7b"
 
         actual = valid_poutyne_version()
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_givenValidPoutyneVersion_thenReturnFalse(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1"
+        poutyne_mock.__version__ = "1.1"
 
         actual = valid_poutyne_version()
         self.assertFalse(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_1_dev_givenValidPoutyneVersion_thenReturnFalse(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.1.dev1+81b3c7b"
+        poutyne_mock.__version__ = "1.1.dev1+81b3c7b"
 
         actual = valid_poutyne_version()
         self.assertFalse(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_8_givenValidPoutyneVersion1_8_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.8"
+        poutyne_mock.__version__ = "1.8"
 
         actual = valid_poutyne_version(min_major=1, min_minor=8)
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion1_11_givenValidPoutyneVersion1_8_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "1.11"
+        poutyne_mock.__version__ = "1.11"
 
         actual = valid_poutyne_version(min_major=1, min_minor=8)
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion2_givenValidPoutyneVersion1_8_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "2.0"
+        poutyne_mock.__version__ = "2.0"
 
         actual = valid_poutyne_version(min_major=1, min_minor=8)
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion2_11_givenValidPoutyneVersion1_8_thenReturnTrue(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "2.11"
+        poutyne_mock.__version__ = "2.11"
 
         actual = valid_poutyne_version(min_major=1, min_minor=8)
         self.assertTrue(actual)
 
     @patch("deepparse.validations.poutyne")
     def test_givenPoutyneVersion2_givenValidPoutyneVersion3_thenReturnFalse(self, poutyne_mock):
-        poutyne_mock.version.__version__ = "2.0"
+        poutyne_mock.__version__ = "2.0"
 
         actual = valid_poutyne_version(min_major=3, min_minor=0)
         self.assertFalse(actual)


### PR DESCRIPTION
Audit du code (suite à `/audit-fix`) : 7 vrais bugs identifiés et corrigés, chacun validé localement (suite unitaire verte 487 passed, pylint 10.00/10, black propre) et par mutation quand applicable.

## Bugs corrigés

| # | Sévérité | Fichier | Problème |
|---|----------|---------|----------|
| 1 | **Haute** | `validations.py` | `extract_package_version` lisait `package.version.__version__`, qui n'existe plus dans Poutyne ≥ 1.18 → `retrain` cassé (`AttributeError`). Lit désormais `package.__version__`. Les tests **mockaient l'attribut cassé**, masquant le bug ; ils exercent maintenant la vraie API. |
| 2 | **Haute** | `network/model_loader.py` | `load_weights` retournait toujours `None` comme version (lue dans le state dict interne au lieu des métadonnées du checkpoint). Nouveau fichier `tests/network/test_model_loader.py`. |
| 3 | **Haute** | `parser/address_parser.py` | `retrain` avalait silencieusement une vraie `RuntimeError` d'entraînement (il inspectait le CWD au lieu du `logging_path`). Re-levée désormais quand il n'y a pas de collision de checkpoint. Test de régression ajouté. |
| 4 | Moyenne | `parser/address_parser.py` | La liste `pre_processors` fournie par l'appelant était mutée (`append`), accumulant des doublons si réutilisée. |
| 5 | Moyenne | `cli/tools.py` | Détection du format d'export par sous-chaîne (`report.pdf` → pickle). Vérifie maintenant la vraie extension. |
| 6 | Moyenne | `cli/tools.py` | `str.strip("attention")` (jeu de caractères) au lieu de `removesuffix("-attention")`. |
| 7 | Cosmétique | `parser/address_parser.py` | Appel mort `self.model.state_dict()` supprimé. |

## Validation

- `pytest` (TEST_LEVEL=unit) : **487 passed, 251 skipped** (+4 nouveaux tests).
- `pylint deepparse/ tests/ examples/` : **10.00/10**.
- `black --check` : propre.
- Mutation testing : pour #1, #2 et #3, réintroduire le bug rend le test rouge (vérifié).

Note : le gros diff de `address_parser.py` vient surtout du dé-indent du bloc `else` (corrige le `no-else-raise` introduit par #3, qui rend l'`except` toujours levant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)