### PR TITLE
fix: second audit pass (API status code, padder mutation, error handling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -429,3 +429,10 @@
 - Fix CLI attention-model handling using `str.strip("attention")` (a character set) to drop the `-attention`
   suffix; it now uses `removesuffix("-attention")`.
 - Remove a no-op `self.model.state_dict()` call in `save_address_parser_weights`.
+- Fix the REST API returning HTTP 500 instead of the documented 422 for an empty address list or an unknown
+  parsing model: `format_parsed_addresses` (used as a FastAPI dependency) raised `ValueError` instead of
+  `HTTPException`.
+- Fix `DataPadder.pad_subword_embeddings_sequences` mutating the caller's decomposition-length lists in place.
+- Replace a `except BaseException` (which also swallowed `KeyboardInterrupt`/`SystemExit`) with `except Exception`
+  when closing HTTP adapters in the BPEmb embeddings model.
+- Fix a missing space in the `DataProcessorFactory` "unsupported vectorizer" error message.

--- a/deepparse/app/tools.py
+++ b/deepparse/app/tools.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Union
 
+from fastapi import HTTPException
+
 from deepparse.app.address import Address
 from deepparse.download_tools import MODEL_MAPPING_CHOICES
 from deepparse.parser import AddressParser
@@ -20,10 +22,14 @@ def format_parsed_addresses(
     Returns:
     - **JSONResponse**: JSON response containing the parsed addresses, along with the model type and version.
     """
+    # These are raised as HTTPException (not ValueError) because this function runs as a FastAPI dependency:
+    # a ValueError would surface as a 500 error instead of the documented 422.
     if not addresses:
-        raise ValueError("Addresses parameter must not be empty")
+        raise HTTPException(status_code=422, detail="Addresses parameter must not be empty")
     if parsing_model not in MODEL_MAPPING_CHOICES:
-        raise ValueError(f"Parsing model not implemented, available choices: {list(MODEL_MAPPING_CHOICES)}")
+        raise HTTPException(
+            status_code=422, detail=f"Parsing model not implemented, available choices: {list(MODEL_MAPPING_CHOICES)}"
+        )
 
     if model_mapping is None:
         model_mapping = address_parser_mapping

--- a/deepparse/converter/data_padder.py
+++ b/deepparse/converter/data_padder.py
@@ -152,11 +152,16 @@ class DataPadder:
         padded_sequences_vectors = self._pad_tensors(sequences_vectors)
 
         longest_sequence_length = max(lengths)
+        # We build new lists rather than mutating the caller's decomposition-length lists in place, so the
+        # original sequences are left untouched (padding must not have side effects on the input batch).
+        padded_decomposition_lengths = []
         for decomposition_length in decomp_len:
-            if len(decomposition_length) < longest_sequence_length:
-                decomposition_length.extend([1] * (longest_sequence_length - len(decomposition_length)))
+            padded_length = list(decomposition_length)
+            if len(padded_length) < longest_sequence_length:
+                padded_length.extend([1] * (longest_sequence_length - len(padded_length)))
+            padded_decomposition_lengths.append(padded_length)
 
-        return padded_sequences_vectors, list(decomp_len), list(lengths)
+        return padded_sequences_vectors, padded_decomposition_lengths, list(lengths)
 
     def pad_targets(self, target_batch: List) -> torch.Tensor:
         """

--- a/deepparse/converter/data_processor_factory.py
+++ b/deepparse/converter/data_processor_factory.py
@@ -35,7 +35,7 @@ class DataProcessorFactory:
         else:
             raise NotImplementedError("""
             There's no data processor corresponding to the provided vectorizer.
-            Supported vectorizers are BPEmbVectorizer, FastTextVectorizerand MagnitudeVectorizer
+            Supported vectorizers are BPEmbVectorizer, FastTextVectorizer and MagnitudeVectorizer
             """)
 
         return processor

--- a/deepparse/embeddings_models/bpemb_embeddings_model.py
+++ b/deepparse/embeddings_models/bpemb_embeddings_model.py
@@ -85,5 +85,5 @@ def no_ssl_verification():
         for adapter in opened_adapters:
             try:
                 adapter.close()
-            except BaseException:  # pylint: disable=W0702, W0703
+            except Exception:  # pylint: disable=broad-except
                 pass

--- a/tests/app/test_tools_validation.py
+++ b/tests/app/test_tools_validation.py
@@ -1,0 +1,29 @@
+import pytest
+
+try:
+    from fastapi import HTTPException
+
+    from deepparse.app.tools import Address, format_parsed_addresses
+
+    APP_DEPS_AVAILABLE = True
+except ModuleNotFoundError:
+    APP_DEPS_AVAILABLE = False
+
+
+# These validations run before any model is loaded, so they are unit-testable without a GPU or downloaded
+# weights. format_parsed_addresses is used as a FastAPI dependency: it must raise HTTPException (-> 422), not
+# ValueError (which FastAPI would surface as a 500).
+@pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (fastapi) is not installed.")
+def test_givenEmptyAddresses_whenFormatParsedAddresses_thenRaisesHTTPException422():
+    with pytest.raises(HTTPException) as exception_info:
+        format_parsed_addresses("bpemb", [])
+
+    assert exception_info.value.status_code == 422
+
+
+@pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (fastapi) is not installed.")
+def test_givenInvalidModel_whenFormatParsedAddresses_thenRaisesHTTPException422():
+    with pytest.raises(HTTPException) as exception_info:
+        format_parsed_addresses("not_a_real_model", [Address(raw="an address")])
+
+    assert exception_info.value.status_code == 422

--- a/tests/converter/test_data_padder.py
+++ b/tests/converter/test_data_padder.py
@@ -203,6 +203,23 @@ class DataPadderTest(TestCase):
 
         self.assertEqual(decomposition_lengths, self.a_non_padded_subword_embedding_batch_decomposition_length_list)
 
+    def test_givenASequencesBatch_whenPaddingSubwordEmbeddings_thenDoesNotMutateInputDecompositionLengths(self):
+        # Padding must not mutate the caller's decomposition-length lists in place. The second ([2, 2]) and
+        # third ([3]) are shorter than the longest sequence (3) and would be padded; the originals must stay
+        # untouched.
+        sequences_batch = [
+            (
+                [[[1, 1], [1, 1], [-1, -1]], [[1, 1], [1, 1], [1, 1]], [[1, 1], [-1, -1], [-1, -1]]],
+                [2, 3, 1],
+            ),
+            ([[[1, 1], [1, 1], [-1, -1]], [[1, 1], [1, 1], [-1, -1]]], [2, 2]),
+            ([[[1, 1], [1, 1], [1, 1]]], [3]),
+        ]
+
+        self.padder.pad_subword_embeddings_sequences(sequences_batch)
+
+        self.assertEqual([decomposition for _, decomposition in sequences_batch], [[2, 3, 1], [2, 2], [3]])
+
     def test_givenASequencesBatch_whenPaddingSubwordEmbeddings_thenShouldReturnBatchAsTensor(self):
         padded_sequences, _, _ = self.padder.pad_subword_embeddings_sequences(
             self.a_non_padded_subword_embedding_sequences_batch


### PR DESCRIPTION
Seconde passe d'audit (suite `/audit-fix`) sur les modules non couverts à la première passe (embeddings, vectorizers, app, converter, download_tools, comparer). 4 vrais bugs corrigés, validés localement (490 passed, pylint 10.00/10, black propre) et par mutation pour les deux principaux.

## Bugs corrigés

| Sévérité | Fichier | Problème |
|----------|---------|----------|
| **Haute** | `app/tools.py` | L'API REST renvoyait **500** au lieu du **422** documenté pour une liste d'adresses vide ou un modèle inconnu : `format_parsed_addresses` (utilisée comme dépendance FastAPI) levait `ValueError` au lieu de `HTTPException`. Les tests app existants masquaient le bug (intégration-only + `dependency_overrides` fuité). Tests unitaires ajoutés (la validation précède tout chargement de modèle → pas de GPU requis). |
| Moyenne | `converter/data_padder.py` | `pad_subword_embeddings_sequences` mutait en place les listes de décomposition de l'appelant. Test de non-mutation ajouté. |
| Moyenne | `embeddings_models/bpemb_embeddings_model.py` | `except BaseException` (avalait `KeyboardInterrupt`/`SystemExit`) → `except Exception`. |
| Cosmétique | `converter/data_processor_factory.py` | Espace manquant dans le message d'erreur "vectorizer non supporté". |

## Écartés (présentés mais non corrigés)
- **Réponse API keyée sur le texte brut** (`app/tools.py`) : deux adresses identiques s'écrasent dans le dict de réponse. Réel mais **changement d'API cassant** (la réponse passerait de dict à liste) → à décider séparément.
- `max()` sur batch vide, propriété `dim` de base, `Content-Length` None : défensifs / by-design, pas corrigés.

## Validation
- `pytest` (unit) : **490 passed, 251 skipped** (+3 tests).
- `pylint deepparse/ tests/ examples/` : **10.00/10**. `black --check` : propre.
- Mutation testing : réintroduire le bug API (422→ValueError) ou la mutation du padder rend les nouveaux tests rouges (vérifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)