### PR TITLE
fix(app): return parsed_addresses as a list to preserve duplicate inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,3 +436,6 @@
 - Replace a `except BaseException` (which also swallowed `KeyboardInterrupt`/`SystemExit`) with `except Exception`
   when closing HTTP adapters in the BPEmb embeddings model.
 - Fix a missing space in the `DataProcessorFactory` "unsupported vectorizer" error message.
+- **Breaking change (REST API)**: the `parse` endpoint now returns `parsed_addresses` as a list of
+  `{raw: parsed}` objects instead of a single object keyed on the raw address. The previous format silently
+  collapsed duplicate input addresses (and lost their order); the list preserves every input.

--- a/deepparse/app/tools.py
+++ b/deepparse/app/tools.py
@@ -11,7 +11,7 @@ address_parser_mapping: Dict[str, AddressParser] = {}
 
 def format_parsed_addresses(
     parsing_model: str, addresses: List[Address], model_mapping=None
-) -> Dict[str, Union[str, Dict[str, str]]]:
+) -> Dict[str, Union[str, List[Dict[str, Dict[str, str]]]]]:
     """
     Format parsed addresses.
 
@@ -41,10 +41,12 @@ def format_parsed_addresses(
 
     response_payload = {
         "model_type": model_mapping[parsing_model].model_type,
-        "parsed_addresses": {
-            raw_address.raw: parsed_address.to_dict()
+        # A list (not a dict keyed on the raw address) so that duplicate input addresses are preserved and the
+        # output order matches the input order.
+        "parsed_addresses": [
+            {raw_address.raw: parsed_address.to_dict()}
             for parsed_address, raw_address in zip(parsed_addresses, addresses)
-        },
+        ],
         "version": model_mapping[parsing_model].version,
     }
 

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -169,7 +169,7 @@ def test_format_parsed_addresses():
     parsed_address_1 = formatted_parsed_address_1.to_dict()
     parsed_address_2 = formatted_parsed_address_2.to_dict()
 
-    expected_parsed_addresses = {raw_address_1: parsed_address_1, raw_address_2: parsed_address_2}
+    expected_parsed_addresses = [{raw_address_1: parsed_address_1}, {raw_address_2: parsed_address_2}]
 
     expected_response = {"model_type": model_type, "parsed_addresses": expected_parsed_addresses, "version": version}
 
@@ -214,9 +214,9 @@ def test_format_parsed_addresses__one_address():
     # Assertions or checks on the response
     parsed_address = formatted_parsed_address.to_dict()
 
-    expected_parsed_address = {
-        raw_address_1: parsed_address,
-    }
+    expected_parsed_address = [
+        {raw_address_1: parsed_address},
+    ]
 
     expected_response = {"model_type": model_type, "parsed_addresses": expected_parsed_address, "version": version}
 

--- a/tests/app/test_tools_validation.py
+++ b/tests/app/test_tools_validation.py
@@ -1,9 +1,12 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 try:
     from fastapi import HTTPException
 
     from deepparse.app.tools import Address, format_parsed_addresses
+    from deepparse.parser import FormattedParsedAddress
 
     APP_DEPS_AVAILABLE = True
 except ModuleNotFoundError:
@@ -27,3 +30,23 @@ def test_givenInvalidModel_whenFormatParsedAddresses_thenRaisesHTTPException422(
         format_parsed_addresses("not_a_real_model", [Address(raw="an address")])
 
     assert exception_info.value.status_code == 422
+
+
+@pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (fastapi) is not installed.")
+def test_givenDuplicateRawAddresses_whenFormatParsedAddresses_thenBothAreKept():
+    # Two identical raw addresses must both appear in the response. Keying the response on the raw text (the
+    # previous behaviour) collapsed them into a single entry, silently losing data.
+    model_type = "bpemb"
+    raw_address = "350 rue des Lilas Ouest Quebec city Quebec G1L 1B6"
+    parsed = FormattedParsedAddress({raw_address: [("350", "StreetNumber"), ("rue des Lilas", "StreetName")]})
+
+    parser_mock = MagicMock()
+    parser_mock.model_type = model_type
+    parser_mock.version = "a_version"
+    parser_mock.return_value = [parsed, parsed]
+
+    response = format_parsed_addresses(
+        model_type, [Address(raw=raw_address), Address(raw=raw_address)], {model_type: parser_mock}
+    )
+
+    assert len(response["parsed_addresses"]) == 2


### PR DESCRIPTION
Suite de l'audit : correctif du finding "réponse API keyée sur le texte brut" (approuvé pour correction).

## Problème

La route `/parse` renvoyait `parsed_addresses` comme un **objet keyé sur le texte brut** de l'adresse :
```python
"parsed_addresses": { raw_address.raw: parsed_address.to_dict() for ... }
```
Deux adresses identiques en entrée **s'écrasaient** → N adresses en entrée, < N en sortie, silencieusement ; l'ordre n'était pas garanti non plus.

## Correctif (changement cassant)

`parsed_addresses` devient une **liste** d'objets `{raw: parsed}` :
```python
"parsed_addresses": [ {raw_address.raw: parsed_address.to_dict()} for ... ]
```
Chaque entrée est préservée, dans l'ordre. Ce format correspond exactement à ce que le test API existant (`test_parse`) attendait déjà (il mockait la dépendance), résolvant une incohérence test/implémentation.

⚠️ **BREAKING CHANGE** sur le contrat de l'API REST : le champ `parsed_addresses` passe d'objet à liste.

## Tests
- Tests directs (`test_format_parsed_addresses`, `__one_address`) mis à jour au format liste.
- Nouveau test unitaire de régression : deux adresses identiques → 2 entrées conservées (mutation-validé : l'ancien dict rend le test rouge).
- Suite : **491 passed, 251 skipped**. pylint **10.00/10**. black propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)