### PR TITLE
fix(network): build attention mask on the model device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,3 +439,5 @@
 - **Breaking change (REST API)**: the `parse` endpoint now returns `parsed_addresses` as a list of
   `{raw: parsed}` objects instead of a single object keyed on the raw address. The previous format silently
   collapsed duplicate input addresses (and lost their order); the list preserves every input.
+- Fix the attention decoder building its length mask on CPU, which raised a device-mismatch error when running
+  an attention model on GPU. The mask now follows the model's device.

--- a/deepparse/network/decoder.py
+++ b/deepparse/network/decoder.py
@@ -116,7 +116,14 @@ class Decoder(nn.Module):
         )
 
         longest_sequence_length = max(lengths)
-        mask = torch.arange(longest_sequence_length)[None, :] < torch.tensor(lengths, device="cpu")[:, None]
+        # The mask must live on the same device as alignments_scores (which follows self.weights), otherwise the
+        # boolean index assignment below raises on GPU. self.weights is a real parameter, so its device is the
+        # model's device.
+        device = self.weights.device
+        mask = (
+            torch.arange(longest_sequence_length, device=device)[None, :]
+            < torch.tensor(lengths, device=device)[:, None]
+        )
         mask = mask.unsqueeze(1)
         alignments_scores[~mask] = float("-inf")
 

--- a/tests/network/test_decoder.py
+++ b/tests/network/test_decoder.py
@@ -5,6 +5,8 @@ import unittest
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
+import torch
+
 from deepparse.network import Decoder
 
 
@@ -104,6 +106,37 @@ class DecoderTest(TestCase):
                                     self.a_lengths_list,
                                 )
                                 self.assertIsNotNone(attention_weights)
+
+    def test_givenAttForwardWithRealTensors_thenMaskZeroesAttentionBeyondEachLength(self):
+        # Real tensors (no mocking of matmul) to exercise the actual masking. The mask must run on the model's
+        # device and zero out attention weights for positions past each sequence's length.
+        decoder = Decoder(
+            self.input_size_dim,
+            self.hidden_size,
+            self.num_layers,
+            self.output_size,
+            attention_mechanism=True,
+        )
+
+        batch_size = 2
+        sequence_length = 3
+        encoder_outputs = torch.ones(batch_size, sequence_length, self.hidden_size)
+        hidden = (
+            torch.ones(self.num_layers, batch_size, self.hidden_size),
+            torch.ones(self.num_layers, batch_size, self.hidden_size),
+        )
+        to_predict = torch.ones(1, batch_size, self.input_size_dim)
+        lengths = [3, 1]  # The second sequence has length 1: positions 1 and 2 must be masked out.
+
+        _, _, attention_weights = decoder.forward(to_predict, hidden, encoder_outputs, lengths)
+
+        # Shape is (batch, 1, sequence_length).
+        self.assertEqual(attention_weights[1, 0, 1].item(), 0.0)
+        self.assertEqual(attention_weights[1, 0, 2].item(), 0.0)
+        # The full-length sequence keeps non-zero attention on every position, and weights sum to 1.
+        self.assertGreater(attention_weights[0, 0, 0].item(), 0.0)
+        self.assertAlmostEqual(attention_weights[0, 0].sum().item(), 1.0, places=5)
+        self.assertAlmostEqual(attention_weights[1, 0].sum().item(), 1.0, places=5)
 
     def test_whenDecoderNotAttForward_thenReturnAttWeightsToNone(self):
         with patch("deepparse.network.nn.LSTM") as lstm_mock:


### PR DESCRIPTION
Itération d'audit : correctif du dernier finding en suspens (masque du décodeur d'attention sur CPU).

## Problème

`Decoder._attention_mechanism_forward` construisait le masque de longueur sur CPU :
```python
mask = torch.arange(longest_sequence_length)[None, :] < torch.tensor(lengths, device="cpu")[:, None]
```
`alignments_scores` suit le device du modèle (GPU si applicable). En PyTorch, `tensor[bool_mask] = val` exige que le masque soit sur **le même device** → sur GPU, l'assignation `alignments_scores[~mask] = -inf` levait une erreur de device. Les modèles à attention ne fonctionnaient donc que sur CPU.

## Correctif

Le masque est construit sur `self.weights.device` (vraie `nn.Parameter`, device du modèle, dont dérive `alignments_scores`). Fonctionne sur CPU et GPU.

## Tests

Le test existant `test_whenDecoderAttForward_thenReturnAttWeights` **mockait `torch.matmul`**, donc ne validait jamais le masquage réel. Ajout de `test_givenAttForwardWithRealTensors_thenMaskZeroesAttentionBeyondEachLength` : vrais tenseurs, vérifie que l'attention est mise à zéro au-delà de la longueur de chaque séquence et somme à 1 (mutation-validé : désactiver le masquage rend le test rouge).

- Suite : **492 passed, 251 skipped**. pylint **10.00/10**. black propre.

Note : le fix de device ne peut pas être validé localement sur GPU (pas de GPU), mais il est correct par la sémantique PyTorch (indexation booléenne same-device) ; le test CPU confirme l'absence de régression et valide la logique de masquage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)