### PR TITLE
security: load checkpoints with torch.load(weights_only=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,3 +441,5 @@
   collapsed duplicate input addresses (and lost their order); the list preserves every input.
 - Fix the attention decoder building its length mask on CPU, which raised a device-mismatch error when running
   an attention model on GPU. The mask now follows the model's device.
+- Security: load model checkpoints with `torch.load(..., weights_only=True)` so a maliciously crafted
+  checkpoint (e.g. an untrusted `path_to_retrained_model`) cannot execute arbitrary code during unpickling.

--- a/deepparse/weights_tools.py
+++ b/deepparse/weights_tools.py
@@ -28,11 +28,14 @@ def weights_init(m: nn.Module) -> None:
 def handle_weights_upload(
     path_to_model_to_upload: Union[str, S3Path], device: Union[str, torch.device] = "cpu"
 ) -> OrderedDict:
+    # weights_only=True restricts unpickling to tensors and basic types, so loading a crafted checkpoint
+    # cannot execute arbitrary code. Deepparse checkpoints only contain a state dict and string metadata,
+    # so this does not affect legitimate models.
     if isinstance(path_to_model_to_upload, S3Path):
         # To handle CloudPath path_to_model_weights
         try:
             with path_to_model_to_upload.open("rb") as file:
-                checkpoint_weights = torch.load(file, map_location=device)
+                checkpoint_weights = torch.load(file, map_location=device, weights_only=True)
         except FileNotFoundError as error:
             raise FileNotFoundError("The file in the S3 bucket was not found.") from error
     elif "s3://" in path_to_model_to_upload:
@@ -40,13 +43,13 @@ def handle_weights_upload(
         path_to_model_to_upload = CloudPath(path_to_model_to_upload)
         try:
             with path_to_model_to_upload.open("rb") as file:
-                checkpoint_weights = torch.load(file, map_location=device)
+                checkpoint_weights = torch.load(file, map_location=device, weights_only=True)
         except FileNotFoundError as error:
             raise FileNotFoundError("The file in the S3 bucket was not found.") from error
     else:
         # Path is a local one (or a wrongly written S3 URI).
         try:
-            checkpoint_weights = torch.load(path_to_model_to_upload, map_location=device)
+            checkpoint_weights = torch.load(path_to_model_to_upload, map_location=device, weights_only=True)
         except FileNotFoundError as error:
             if "s3" in path_to_model_to_upload or "//" in path_to_model_to_upload or ":" in path_to_model_to_upload:
                 raise FileNotFoundError(

--- a/tests/test_weights_tools.py
+++ b/tests/test_weights_tools.py
@@ -50,6 +50,24 @@ class WeightsToolsTests(TestCase):
 
         cloud_path_mock.assert_not_called()
 
+    @patch("deepparse.weights_tools.CloudPath")
+    @patch("deepparse.weights_tools.torch")
+    def test_givenALocalPath_whenHandleWeightsUpload_thenLoadsWithWeightsOnly(self, torch_mock, cloud_path_mock):
+        # Security: torch.load must be called with weights_only=True so a crafted checkpoint cannot execute
+        # arbitrary code during unpickling.
+        handle_weights_upload(path_to_model_to_upload="a_normal_path.ckpt")
+
+        _, load_kwargs = torch_mock.load.call_args
+        self.assertTrue(load_kwargs.get("weights_only"))
+        cloud_path_mock.assert_not_called()
+
+    @patch("deepparse.weights_tools.torch")
+    def test_givenAnS3Path_whenHandleWeightsUpload_thenLoadsWithWeightsOnly(self, torch_mock):
+        handle_weights_upload(path_to_model_to_upload=MagicMock(spec=S3Path))
+
+        _, load_kwargs = torch_mock.load.call_args
+        self.assertTrue(load_kwargs.get("weights_only"))
+
     def test_givenAWrongfullyStringS3Path_whenHandleWeights_upload_thenRaiseError(self):
         s3_path = "s3/model.ckpt"
 


### PR DESCRIPTION
Audit de sécurité du code deepparse. Correctif du finding le plus actionnable : désérialisation non sûre de checkpoints.

## Problème (RCE potentiel)

`weights_tools.handle_weights_upload` charge les checkpoints via `torch.load(...)` sans `weights_only`. `torch.load` dépickle des objets arbitraires → **exécution de code arbitraire** si on charge un checkpoint malveillant. La surface est réelle : `AddressParser(path_to_retrained_model=...)` accepte un chemin local **ou une URI S3** fournis par l'utilisateur/un tiers.

## Correctif

`torch.load(..., weights_only=True)` sur les 3 chemins (S3Path, URI s3://, local). Restreint le dépicklage aux tenseurs et types de base. Les checkpoints deepparse ne contiennent qu'un state dict + métadonnées (str) → modèles légitimes non affectés (vérifié : `weights_only=True` charge correctement un checkpoint deepparse).

## Tests
- Tests asserttant que `weights_only=True` est bien passé (mutation-validé : le retirer rend les tests rouges).
- Suite : **494 passed, 251 skipped**. pylint **10.00/10**. black propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)