### PR TITLE
security: SSL-on-by-default for BPEmb download (with failsafe) + pickle warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,3 +443,8 @@
   an attention model on GPU. The mask now follows the model's device.
 - Security: load model checkpoints with `torch.load(..., weights_only=True)` so a maliciously crafted
   checkpoint (e.g. an untrusted `path_to_retrained_model`) cannot execute arbitrary code during unpickling.
+- Security: download the BPEmb embeddings with SSL verification enabled by default. Verification is now only
+  disabled as a failsafe (with a warning) if an SSL error occurs, instead of unconditionally. The previous
+  behaviour exposed the download to man-in-the-middle tampering.
+- Security: document that `PickleDatasetContainer` must only be used with trusted pickle files, since
+  unpickling executes arbitrary code.

--- a/deepparse/dataset_container/dataset_container.py
+++ b/deepparse/dataset_container/dataset_container.py
@@ -180,6 +180,11 @@ class PickleDatasetContainer(DatasetContainer):
     """
     Pickle dataset container that imports a list of addresses in pickle format and does some validation on it.
 
+    .. warning::
+        This container uses Python's ``pickle`` to load the dataset. Unpickling executes arbitrary code, so
+        only load pickle files you created yourself or fully trust. Never load a pickle file from an untrusted
+        or third-party source.
+
     The dataset needs to be a list of tuples where the first element of each tuple is the address (a string),
     and the second is a list of the expected tag to predict (e.g. ``[('an address', ['a_tag', 'another_tag']), ...]``).
     The length of the tags needs to be the same as the length of the address when the whitespace-split is used.

--- a/deepparse/embeddings_models/bpemb_embeddings_model.py
+++ b/deepparse/embeddings_models/bpemb_embeddings_model.py
@@ -1,4 +1,6 @@
 import contextlib
+import logging
+import ssl
 import warnings
 from pathlib import Path
 from typing import Any, Dict
@@ -9,6 +11,8 @@ from urllib3.exceptions import InsecureRequestWarning
 
 from ..bpemb_url_bug_fix import BPEmbBaseURLWrapperBugFix
 from .embeddings_model import EmbeddingsModel
+
+logger = logging.getLogger(__name__)
 
 
 class BPEmbEmbeddingsModel(EmbeddingsModel):
@@ -28,13 +32,30 @@ class BPEmbEmbeddingsModel(EmbeddingsModel):
             # annoying scipy.sparcetools private module warnings removal
             # annoying boto warnings
             warnings.filterwarnings("ignore")
-            # hotfix until https://github.com/bheinzerling/bpemb/issues/63
-            # is resolved.
+            self.model = self._load_bpemb_model(cache_dir)
+
+    def _load_bpemb_model(self, cache_dir: str) -> BPEmbBaseURLWrapperBugFix:
+        """
+        Download (if needed) and load the BPEmb model. We download with SSL verification enabled. The BPEmb
+        host (set by :class:`BPEmbBaseURLWrapperBugFix`) currently has a valid certificate, but it has broken
+        before (`bpemb issue 63 <https://github.com/bheinzerling/bpemb/issues/63>`_). As a failsafe, and only
+        if an SSL error occurs, we retry once with verification disabled while warning loudly, so a transient
+        upstream certificate problem does not break Deepparse outright.
+
+        We use the default parameters other than the dim at 300 and a vs of 100,000.
+        """
+        model_kwargs = {"lang": "multi", "vs": 100000, "dim": 300, "cache_dir": Path(cache_dir)}
+        try:
+            return BPEmbBaseURLWrapperBugFix(**model_kwargs)
+        except (requests.exceptions.SSLError, ssl.SSLError) as ssl_error:
+            logger.warning(
+                "SSL verification failed while downloading the BPEmb embeddings. Retrying once without SSL "
+                "verification as a failsafe; this is insecure (man-in-the-middle risk). If it persists, the "
+                "BPEmb host certificate is likely broken again (see bpemb issue 63). Original error: %s",
+                ssl_error,
+            )
             with no_ssl_verification():
-                # We use the default parameters other than the dim at 300 and a vs of 100,000
-                # We use a BPEmb wrapper since the base URL is broken and the issue is not resolved as of june 23rd.
-                model = BPEmbBaseURLWrapperBugFix(lang="multi", vs=100000, dim=300, cache_dir=Path(cache_dir))
-        self.model = model
+                return BPEmbBaseURLWrapperBugFix(**model_kwargs)
 
     def __call__(self, word: str) -> ndarray:
         """

--- a/tests/embeddings_models/test_bpemb_embeddings_model.py
+++ b/tests/embeddings_models/test_bpemb_embeddings_model.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import requests
+
 from deepparse.embeddings_models import BPEmbEmbeddingsModel
 
 
@@ -25,6 +27,30 @@ class BPEmbEmbeddingsModelTest(TestCase):
             _ = BPEmbEmbeddingsModel(self.a_path, verbose=False)
 
             loader.assert_called_with(lang="multi", vs=100000, dim=300, cache_dir=Path(self.a_path))
+
+    def test_whenInstantiatedAndDownloadSucceeds_thenSSLVerificationIsNotDisabled(self):
+        # The default path must download with SSL verification ON: no_ssl_verification must not be entered.
+        with patch(
+            "deepparse.embeddings_models.bpemb_embeddings_model.BPEmbBaseURLWrapperBugFix",
+            return_value=self.model,
+        ):
+            with patch("deepparse.embeddings_models.bpemb_embeddings_model.no_ssl_verification") as no_ssl_mock:
+                BPEmbEmbeddingsModel(self.a_path, verbose=False)
+
+            no_ssl_mock.assert_not_called()
+
+    def test_whenDownloadRaisesSSLError_thenFailsafeRetriesWithoutSSLVerification(self):
+        # Failsafe: on an SSL error, retry once inside no_ssl_verification and still return a working model.
+        with patch(
+            "deepparse.embeddings_models.bpemb_embeddings_model.BPEmbBaseURLWrapperBugFix",
+            side_effect=[requests.exceptions.SSLError("broken certificate"), self.model],
+        ) as loader:
+            with patch("deepparse.embeddings_models.bpemb_embeddings_model.no_ssl_verification") as no_ssl_mock:
+                embeddings_model = BPEmbEmbeddingsModel(self.a_path, verbose=False)
+
+            no_ssl_mock.assert_called_once()
+            self.assertEqual(loader.call_count, 2)
+            self.assertIs(embeddings_model.model, self.model)
 
     def test_whenCalledToEmbed_thenShouldCallLoadedModel(self):
         with patch(


### PR DESCRIPTION
Suite de l'audit sécurité. Deux findings traités.

## 1. SSL désactivé au téléchargement BPEmb (MITM) — corrigé avec failsafe

`BPEmbEmbeddingsModel` téléchargeait **toujours** les embeddings avec `verify=False` (`no_ssl_verification`), un contournement de l'ancienne URL cassée (bpemb issue #63). 

**Validation** : le host actuel `bpemb.h-its.org` a un **certificat valide** (DigiCert, exp. oct. 2026, `ssl_verify_result=0`). Le contournement inconditionnel était donc obsolète et exposait le download à du MITM (puis chargement du modèle).

**Correctif (avec failsafe demandé)** : download avec vérification SSL **activée par défaut** ; on ne bascule en non-vérifié qu'en **dernier recours**, uniquement si une erreur SSL survient, en logguant un avertissement. Résilient si l'upstream recasse, sans exposer le cas nominal.

## 2. `pickle.load` non fiable — documenté

`PickleDatasetContainer` dépickle le dataset (exécution de code arbitraire). Ajout d'un avertissement de sécurité dans la docstring : ne charger que des fichiers pickle de confiance.

## Tests
- `test_whenInstantiatedAndDownloadSucceeds_thenSSLVerificationIsNotDisabled` (chemin nominal sécurisé).
- `test_whenDownloadRaisesSSLError_thenFailsafeRetriesWithoutSSLVerification` (failsafe).
- Mutation-validé. Suite : **496 passed, 251 skipped**. pylint **10.00/10**. black propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)