### PR TITLE
security: harden REST API (DoS limit, Sentry/PII) and Docker image (non-root, digest pins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,3 +448,9 @@
   behaviour exposed the download to man-in-the-middle tampering.
 - Security: document that `PickleDatasetContainer` must only be used with trusted pickle files, since
   unpickling executes arbitrary code.
+- Security (REST API): reject requests with more than `MAX_ADDRESSES_PER_REQUEST` addresses (default 1024,
+  env-overridable) with HTTP 413, to prevent resource-exhaustion denial of service.
+- Security (Sentry): default `traces`/`profiles` sample rates to 0.1 (env-overridable via
+  `SENTRY_TRACES_SAMPLE_RATE`/`SENTRY_PROFILES_SAMPLE_RATE`), never capture request bodies, and disable PII
+  sending, since parsed addresses are personal data.
+- Security (Docker): run the app image as a non-root user and pin the base images by digest.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax = docker/dockerfile:experimental
-FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
+# Base images are pinned by digest (in addition to the tag) so the build is reproducible and not silently
+# swapped under a mutable tag.
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime@sha256:c8268a92a69bd500f8be0e665b2630ee006dadaf7bfbc24249141b15ff622755
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -33,14 +35,15 @@ RUN find /opt/conda/lib/ -follow -type f -name '*.a' -delete \
 ENV PATH /opt/conda/bin:$PATH
 
 
-FROM python:3.13-slim AS app
-# set work directory
+FROM python:3.13-slim@sha256:c33f0bc4364a6881bed1ec0cc2665e6c53c87a43e774aaeab88e6f17af105e4f AS app
 
 # set env variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV ENVIRONMENT=local
 
+# set work directory
+WORKDIR /app
 
 # copy project
 COPY /deepparse ./deepparse
@@ -49,3 +52,7 @@ COPY setup.py ./
 COPY README.md ./
 COPY version.txt ./
 RUN pip install -e .[app]
+
+# Run as a non-root user (least privilege). The model cache lives under this user's home.
+RUN useradd --create-home --uid 1000 appuser && chown -R appuser:appuser /app
+USER appuser

--- a/deepparse/app/sentry.py
+++ b/deepparse/app/sentry.py
@@ -7,14 +7,22 @@ from decouple import config
 
 
 def configure_sentry() -> None:
-    """Configure Sentry."""
+    """Configure Sentry.
+
+    Sampling rates default to a conservative 0.1 and are overridable via the ``SENTRY_TRACES_SAMPLE_RATE`` and
+    ``SENTRY_PROFILES_SAMPLE_RATE`` environment variables. Request bodies are never captured and PII sending is
+    off, since parsed addresses are personal data and must not be shipped to a third party.
+    """
     sentry_dsn = config("SENTRY_DSN", "")
     environment = config("ENVIRONMENT", "local")
+    traces_sample_rate = config("SENTRY_TRACES_SAMPLE_RATE", 0.1, cast=float)
+    profiles_sample_rate = config("SENTRY_PROFILES_SAMPLE_RATE", 0.1, cast=float)
     sentry_sdk.init(
         dsn=sentry_dsn,
-        traces_sample_rate=1.0,
+        traces_sample_rate=traces_sample_rate,
         release=f"deepparse@{get_version('deepparse')}",
-        profiles_sample_rate=1.0,
+        profiles_sample_rate=profiles_sample_rate,
         environment=environment,
-        max_request_body_size="small",
+        max_request_body_size="never",
+        send_default_pii=False,
     )

--- a/deepparse/app/tools.py
+++ b/deepparse/app/tools.py
@@ -1,5 +1,6 @@
 from typing import Dict, List, Union
 
+from decouple import config
 from fastapi import HTTPException
 
 from deepparse.app.address import Address
@@ -7,6 +8,10 @@ from deepparse.download_tools import MODEL_MAPPING_CHOICES
 from deepparse.parser import AddressParser
 
 address_parser_mapping: Dict[str, AddressParser] = {}
+
+# Upper bound on the number of addresses accepted per request, to avoid resource exhaustion (DoS) from an
+# arbitrarily large payload. Overridable via the MAX_ADDRESSES_PER_REQUEST environment variable.
+MAX_ADDRESSES_PER_REQUEST = config("MAX_ADDRESSES_PER_REQUEST", 1024, cast=int)
 
 
 def format_parsed_addresses(
@@ -26,6 +31,11 @@ def format_parsed_addresses(
     # a ValueError would surface as a 500 error instead of the documented 422.
     if not addresses:
         raise HTTPException(status_code=422, detail="Addresses parameter must not be empty")
+    if len(addresses) > MAX_ADDRESSES_PER_REQUEST:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Too many addresses in a single request (max {MAX_ADDRESSES_PER_REQUEST}).",
+        )
     if parsing_model not in MODEL_MAPPING_CHOICES:
         raise HTTPException(
             status_code=422, detail=f"Parsing model not implemented, available choices: {list(MODEL_MAPPING_CHOICES)}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - "/$HOME/.cache/deepparse:/root/.cache/deepparse"
+      - "/$HOME/.cache/deepparse:/home/appuser/.cache/deepparse"
     environment:
       - SENTRY_DSN=${SENTRY_DSN}

--- a/tests/app/test_sentry.py
+++ b/tests/app/test_sentry.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+import pytest
+
+try:
+    from deepparse.app import sentry as sentry_module
+
+    APP_DEPS_AVAILABLE = True
+except ModuleNotFoundError:
+    APP_DEPS_AVAILABLE = False
+
+
+@pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (sentry-sdk) is not installed.")
+def test_configureSentry_usesConservativeSamplingAndDoesNotSendPII():
+    # config(key, default, cast=...) -> we return the default so the test pins the safe defaults.
+    def fake_config(key, default=None, cast=None):  # pylint: disable=unused-argument
+        return default
+
+    with patch.object(sentry_module, "sentry_sdk") as sentry_mock:
+        with patch.object(sentry_module, "config", side_effect=fake_config):
+            sentry_module.configure_sentry()
+
+    _, init_kwargs = sentry_mock.init.call_args
+    # Conservative sampling defaults (not 1.0) to limit volume and third-party data exposure.
+    assert init_kwargs["traces_sample_rate"] == 0.1
+    assert init_kwargs["profiles_sample_rate"] == 0.1
+    # Parsed addresses are personal data: never ship request bodies or PII to Sentry.
+    assert init_kwargs["max_request_body_size"] == "never"
+    assert init_kwargs["send_default_pii"] is False

--- a/tests/app/test_tools_validation.py
+++ b/tests/app/test_tools_validation.py
@@ -1,10 +1,11 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 try:
     from fastapi import HTTPException
 
+    from deepparse.app import tools as app_tools
     from deepparse.app.tools import Address, format_parsed_addresses
     from deepparse.parser import FormattedParsedAddress
 
@@ -30,6 +31,16 @@ def test_givenInvalidModel_whenFormatParsedAddresses_thenRaisesHTTPException422(
         format_parsed_addresses("not_a_real_model", [Address(raw="an address")])
 
     assert exception_info.value.status_code == 422
+
+
+@pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (fastapi) is not installed.")
+def test_givenTooManyAddresses_whenFormatParsedAddresses_thenRaisesHTTPException413():
+    # Guard against resource-exhaustion (DoS): a request over the limit must be rejected before any parsing.
+    with patch.object(app_tools, "MAX_ADDRESSES_PER_REQUEST", 2):
+        with pytest.raises(HTTPException) as exception_info:
+            format_parsed_addresses("bpemb", [Address(raw="a"), Address(raw="b"), Address(raw="c")])
+
+    assert exception_info.value.status_code == 413
 
 
 @pytest.mark.skipif(not APP_DEPS_AVAILABLE, reason="The app extra (fastapi) is not installed.")


### PR DESCRIPTION
Audit sécurité de l'API endpoint, du Dockerfile et du déploiement. 4 durcissements (tous demandés).

## API (`app/tools.py`, `app/sentry.py`)
- **DoS / taille de requête** : `/parse` acceptait une liste d'adresses illimitée. Ajout d'une borne `MAX_ADDRESSES_PER_REQUEST` (défaut **1024**, surchargeable par env) → **HTTP 413** au-delà. Empêche l'épuisement CPU/mémoire.
- **Sentry / PII** : `traces`/`profiles_sample_rate` passaient à **1.0** (100 %) et capturaient les corps de requête. Les adresses sont des **données personnelles**. Désormais : défaut **0.1** (surchargeable via `SENTRY_TRACES_SAMPLE_RATE`/`SENTRY_PROFILES_SAMPLE_RATE`), `max_request_body_size="never"`, `send_default_pii=False`.

## Docker (`Dockerfile`, `docker-compose.yml`)
- **Non-root** : le stage `app` tournait en root. Ajout d'un utilisateur `appuser` (uid 1000) + `USER appuser` + `WORKDIR /app`. Mount cache compose aligné sur `/home/appuser/.cache/deepparse`.
- **Digest pinning** : images de base épinglées par digest SHA256 (en plus du tag) — `pytorch:2.5.1-...@sha256:c826...`, `python:3.13-slim@sha256:c33f...` — builds reproductibles et résistants au tampering de tag.

## Tests
- `test_givenTooManyAddresses_...thenRaisesHTTPException413` (limite DoS).
- `test_configureSentry_usesConservativeSamplingAndDoesNotSendPII` (config Sentry).
- Mutation-validés. Suite : **498 passed, 251 skipped**. pylint **10.00/10**. black propre.
- Le build Docker est validé par le workflow "Docker Image CI".

Note : les findings BASSE non corrigés (auth/CORS/rate-limiting applicatif, incohérence de port 8080/8000) sont des décisions de déploiement laissées à l'appréciation des mainteneurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)